### PR TITLE
v0.7.2: testing, hardening, and engine client refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Vet backend
         run: go vet ./...
 
-      - name: Test backend
-        run: go test ./...
+      - name: Test backend with coverage
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
-      - name: Race test backend
-        run: go test -race ./...
+      - name: Display coverage
+        run: go tool cover -func=coverage.out
 
       - name: Build backend (verify embed)
         run: go build -v ./cmd/pulse

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 
 # code coverage
 coverage
+coverage.out
 *.lcov
 
 # logs

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/divijg19/Pulse/internal/model"
+	"github.com/divijg19/Pulse/internal/stream"
+)
+
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (f *flushRecorder) Flush() {}
+
+func TestHandleRun_MethodNotAllowed(t *testing.T) {
+	hub := stream.NewHub()
+	handler := &RunHandler{Hub: hub}
+
+	req := httptest.NewRequest(http.MethodGet, "/run", nil)
+	rec := httptest.NewRecorder()
+	handler.HandleRun(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d (expected %d)", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestHandleRun_InvalidBody(t *testing.T) {
+	hub := stream.NewHub()
+	handler := &RunHandler{Hub: hub}
+
+	t.Run("malformed json", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(`{bad`))
+		rec := httptest.NewRecorder()
+		handler.HandleRun(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d (expected %d)", rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("unknown fields", func(t *testing.T) {
+		body := `{"url":"https://example.com","method":"GET","concurrency":1,"unknown":"field"}`
+		req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		handler.HandleRun(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d (expected %d)", rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		body := `{"url":"","method":"GET","concurrency":1}`
+		req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		handler.HandleRun(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d (expected %d)", rec.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+func TestHandleRun_OversizedBody(t *testing.T) {
+	hub := stream.NewHub()
+	handler := &RunHandler{Hub: hub}
+
+	padding := maxRunRequestBodyBytes + 1 - len(`{"k":""}`)
+	body := strings.NewReader(`{"k":"` + strings.Repeat("v", padding) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/run", body)
+	rec := httptest.NewRecorder()
+	handler.HandleRun(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d (expected %d): body = %q", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+	}
+}
+
+func TestHandleRun_Valid(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	hub := stream.NewHub()
+	handler := &RunHandler{Hub: hub}
+
+	body := `{"url":"` + upstream.URL + `","method":"GET","headers":{},"body":"","concurrency":1}`
+	req := httptest.NewRequest(http.MethodPost, "/run", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandleRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d (expected %d): body = %q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), upstream.URL) {
+		t.Fatalf("response does not include URL: %q", rec.Body.String())
+	}
+}
+
+func TestStreamHandler_Headers(t *testing.T) {
+	hub := stream.NewHub()
+	handler := &StreamHandler{Hub: hub}
+
+	rec := &flushRecorder{httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+	handler.ServeHTTP(rec, req)
+
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Fatalf("Cache-Control = %q", cc)
+	}
+}
+
+func TestStreamHandler_Integration(t *testing.T) {
+	hub := stream.NewHub()
+	handler := &StreamHandler{Hub: hub}
+
+	rec := &flushRecorder{httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "/stream", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		handler.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(5 * time.Millisecond)
+
+	hub.Broadcast(model.Event{Type: "result", Data: model.Result{Status: 200, Latency: 100 * time.Millisecond}})
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not exit after cancellation")
+	}
+
+	body := strings.TrimRight(rec.Body.String(), "\n")
+	lines := strings.Split(body, "\n")
+
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), body)
+	}
+	if !strings.HasPrefix(lines[0], "event: result") {
+		t.Fatalf("line 0 = %q", lines[0])
+	}
+	if !strings.Contains(lines[1], `"status":200`) {
+		t.Fatalf("line 1 = %q", lines[1])
+	}
+	if !strings.Contains(lines[1], `"latencyNs"`) {
+		t.Fatalf("line 1 missing latencyNs: %q", lines[1])
+	}
+}

--- a/internal/api/stream.go
+++ b/internal/api/stream.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/divijg19/Pulse/internal/model"
 	"github.com/divijg19/Pulse/internal/runconfig"
@@ -20,6 +21,8 @@ func (h *StreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 		return
 	}
+
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -31,7 +31,7 @@ func ExecuteConcurrent(ctx context.Context, runReq model.RunRequest, hub *stream
 			}
 
 			// 1. Make the HTTP call
-			res := ExecuteSingle(ctx, runReq.URL, runReq.Method, runReq.Headers, runReq.Body)
+			res := ExecuteSingle(ctx, defaultClient, runReq.URL, runReq.Method, runReq.Headers, runReq.Body)
 			if ctx.Err() != nil {
 				return
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/divijg19/Pulse/internal/stream"
 )
 
+var testClient = &http.Client{Timeout: 30 * time.Second}
+
 func TestExecuteSingle_Happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -19,7 +21,7 @@ func TestExecuteSingle_Happy(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	result := ExecuteSingle(context.Background(), srv.URL, "GET", nil, "")
+	result := ExecuteSingle(context.Background(), testClient, srv.URL, "GET", nil, "")
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -43,7 +45,7 @@ func TestExecuteSingle_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	result := ExecuteSingle(ctx, srv.URL, "GET", nil, "")
+	result := ExecuteSingle(ctx, testClient, srv.URL, "GET", nil, "")
 	if result.Status != 0 {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -53,7 +55,7 @@ func TestExecuteSingle_Timeout(t *testing.T) {
 }
 
 func TestExecuteSingle_Error(t *testing.T) {
-	result := ExecuteSingle(context.Background(), "http://127.0.0.1:1", "GET", nil, "")
+	result := ExecuteSingle(context.Background(), testClient, "http://127.0.0.1:1", "GET", nil, "")
 	if result.Status != 0 {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -79,7 +81,7 @@ func TestExecuteSingle_WithHeadersAndBody(t *testing.T) {
 	defer srv.Close()
 
 	headers := map[string]string{"X-Custom": "test-value"}
-	result := ExecuteSingle(context.Background(), srv.URL, "POST", headers, `{"key":"value"}`)
+	result := ExecuteSingle(context.Background(), testClient, srv.URL, "POST", headers, `{"key":"value"}`)
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -97,7 +99,7 @@ func TestExecuteSingle_RequestMethodURL_OnTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	result := ExecuteSingle(ctx, srv.URL, "POST", nil, "")
+	result := ExecuteSingle(ctx, testClient, srv.URL, "POST", nil, "")
 	if result.RequestMethod != "POST" {
 		t.Fatalf("RequestMethod = %q", result.RequestMethod)
 	}
@@ -107,7 +109,7 @@ func TestExecuteSingle_RequestMethodURL_OnTimeout(t *testing.T) {
 }
 
 func TestExecuteSingle_RequestMethodURL_OnConnectError(t *testing.T) {
-	result := ExecuteSingle(context.Background(), "http://127.0.0.1:1", "DELETE", nil, "")
+	result := ExecuteSingle(context.Background(), testClient, "http://127.0.0.1:1", "DELETE", nil, "")
 	if result.RequestMethod != "DELETE" {
 		t.Fatalf("RequestMethod = %q", result.RequestMethod)
 	}

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -12,9 +12,9 @@ import (
 
 const maxResponseBodyBytes int64 = 10 * 1024
 
-var requestClient = &http.Client{Timeout: 30 * time.Second}
+var defaultClient = &http.Client{Timeout: 30 * time.Second}
 
-func ExecuteSingle(ctx context.Context, url string, method string, headers map[string]string, body string) model.Result {
+func ExecuteSingle(ctx context.Context, cli *http.Client, url string, method string, headers map[string]string, body string) model.Result {
 	start := time.Now()
 
 	var requestBody io.Reader
@@ -33,7 +33,7 @@ func ExecuteSingle(ctx context.Context, url string, method string, headers map[s
 		req.Header.Add(key, value)
 	}
 
-	resp, err := requestClient.Do(req)
+	resp, err := cli.Do(req)
 	if err != nil {
 		return model.Result{Status: 0, Latency: 0, Timestamp: start, Error: err.Error(), RequestMethod: method, RequestURL: url}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,7 +3,9 @@ package server
 import (
 	"fmt"
 	"io/fs"
+	"log"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/divijg19/Pulse/internal/api"
@@ -15,6 +17,18 @@ const DefaultAddr = ":8080"
 type Options struct {
 	Addr     string
 	StaticFS fs.FS
+}
+
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("PANIC: %v\n%s", rec, debug.Stack())
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }
 
 func NewHandler(staticFS fs.FS) http.Handler {
@@ -33,7 +47,7 @@ func NewHandler(staticFS fs.FS) http.Handler {
 	mux.HandleFunc("/run", runHandler.HandleRun)
 	mux.Handle("/stream", &api.StreamHandler{Hub: hub})
 
-	return mux
+	return recoveryMiddleware(mux)
 }
 
 func New(opts Options) *http.Server {
@@ -47,6 +61,7 @@ func New(opts Options) *http.Server {
 		Handler:           NewHandler(opts.StaticFS),
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       60 * time.Second,
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -70,6 +70,21 @@ func TestRunAcceptsValidPayload(t *testing.T) {
 	}
 }
 
+func TestPanicRecovery(t *testing.T) {
+	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+	handler := recoveryMiddleware(panicking)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d (expected 500)", rec.Code)
+	}
+}
+
 func testStaticFS() fstest.MapFS {
 	return fstest.MapFS{
 		"index.html": {Data: []byte("<html></html>")},

--- a/internal/stream/hub_test.go
+++ b/internal/stream/hub_test.go
@@ -1,0 +1,164 @@
+package stream
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/divijg19/Pulse/internal/model"
+)
+
+func TestHub_AddRemove(t *testing.T) {
+	hub := NewHub()
+	ch := make(chan model.Event, 10)
+
+	hub.Add(ch)
+	hub.Broadcast(model.Event{Type: "result", Data: "hello"})
+
+	select {
+	case event := <-ch:
+		if event.Type != "result" {
+			t.Fatalf("event type = %q", event.Type)
+		}
+		if event.Data != "hello" {
+			t.Fatalf("event data = %v", event.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive broadcast")
+	}
+
+	hub.Remove(ch)
+
+	_, ok := <-ch
+	if ok {
+		t.Fatal("channel should be closed after remove")
+	}
+}
+
+func TestHub_RemoveIdempotent(t *testing.T) {
+	hub := NewHub()
+	ch := make(chan model.Event, 10)
+
+	hub.Add(ch)
+	hub.Remove(ch)
+	hub.Remove(ch)
+}
+
+func TestHub_Broadcast_Multiple(t *testing.T) {
+	hub := NewHub()
+
+	ch1 := make(chan model.Event, 100)
+	ch2 := make(chan model.Event, 100)
+	ch3 := make(chan model.Event, 100)
+
+	hub.Add(ch1)
+	hub.Add(ch2)
+	hub.Add(ch3)
+
+	for i := range 10 {
+		hub.Broadcast(model.Event{Type: "result", Data: i})
+	}
+
+	hub.Remove(ch1)
+	hub.Remove(ch2)
+	hub.Remove(ch3)
+
+	for _, ch := range []<-chan model.Event{ch1, ch2, ch3} {
+		count := 0
+		for event := range ch {
+			count++
+			if event.Type != "result" {
+				t.Fatalf("event type = %q", event.Type)
+			}
+		}
+		if count != 10 {
+			t.Fatalf("received %d events (expected 10)", count)
+		}
+	}
+}
+
+func TestHub_SlowConsumer(t *testing.T) {
+	hub := NewHub()
+
+	fast := make(chan model.Event, 100)
+	slow := make(chan model.Event, 1)
+
+	hub.Add(fast)
+	hub.Add(slow)
+
+	for i := range 20 {
+		hub.Broadcast(model.Event{Type: "result", Data: i})
+	}
+
+	hub.Remove(fast)
+	hub.Remove(slow)
+
+	fastCount := 0
+	for range fast {
+		fastCount++
+	}
+
+	slowCount := 0
+	for range slow {
+		slowCount++
+	}
+
+	if fastCount != 20 {
+		t.Fatalf("fast consumer got %d (expected 20)", fastCount)
+	}
+	if slowCount == 20 {
+		t.Fatalf("slow consumer got all 20 — non-blocking broadcast may not be working")
+	}
+	if slowCount == 0 {
+		t.Fatalf("slow consumer got 0 — should have received at least 1 before buffer filled")
+	}
+}
+
+func TestHub_ConcurrentAccess(t *testing.T) {
+	hub := NewHub()
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch := make(chan model.Event, 10)
+			hub.Add(ch)
+			for range 5 {
+				hub.Broadcast(model.Event{Type: "result"})
+			}
+			hub.Remove(ch)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestHub_BroadcastEmpty(t *testing.T) {
+	hub := NewHub()
+	hub.Broadcast(model.Event{Type: "result", Data: "no clients"})
+}
+
+func TestHub_ClientOrder(t *testing.T) {
+	hub := NewHub()
+	ch := make(chan model.Event, 10)
+	hub.Add(ch)
+
+	for i := range 5 {
+		hub.Broadcast(model.Event{Type: "result", Data: i})
+	}
+
+	hub.Remove(ch)
+
+	expected := 0
+	for event := range ch {
+		val, ok := event.Data.(int)
+		if !ok {
+			t.Fatalf("data is not int: %T", event.Data)
+		}
+		if val != expected {
+			t.Fatalf("received %d (expected %d)", val, expected)
+		}
+		expected++
+	}
+}


### PR DESCRIPTION
- Tests for internal/api (6 tests): HandleRun method-not allowed, invalid body, oversized body, valid payload; StreamHandler headers and SSE integration
- Tests for internal/stream (7 tests): AddRemove, RemoveIdempotent, Broadcast multiple, SlowConsumer, ConcurrentAccess, BroadcastEmpty, ClientOrder
- Server hardening: panic-recovery middleware with debug.Stack logging, WriteTimeout 30s on HTTP server
- SSE: SetWriteDeadline(time.Time{}) exemption via ResponseController
- Engine: ExecuteSingle now accepts *http.Client param for testability; defaultClient kept as package-level default
- CI: coverage profile generation and display in pipeline
- .gitignore: coverage.out added