### PR TITLE
v0.7.3 TUI redesign + comprehensive tests

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -32,7 +32,7 @@ const (
 const (
 	subfocusKey      = 0
 	subfocusValue    = 1
-	latencyRingSize  = 40
+	latencyRingSize  = 200
 	defaultBodyWidth = 48
 	maxTUIBodyBytes  = 1 << 20
 )
@@ -147,11 +147,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.latencyLen < latencyRingSize {
 			m.latencyLen++
 		}
+		before := len(m.results)
 		if len(m.results) < 10000 {
 			m.results = append(m.results, msg.Result)
 		}
 		m.summary = metrics.Compute(m.results, m.elapsed)
-		if m.autoScroll && m.selected >= len(m.results)-1 {
+		if m.autoScroll && m.selected >= before-1 {
 			m.selected = len(m.results) - 1
 		}
 		if m.running && m.eventCh != nil {
@@ -505,5 +506,11 @@ func formatDuration(duration time.Duration) string {
 	if duration <= 0 {
 		return "0.00s"
 	}
-	return fmt.Sprintf("%.2fs", duration.Seconds())
+	secs := duration.Seconds()
+	if secs >= 60 {
+		mins := int(secs) / 60
+		left := secs - float64(mins*60)
+		return fmt.Sprintf("%dm %.0fs", mins, left)
+	}
+	return fmt.Sprintf("%.2fs", secs)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -186,11 +186,280 @@ func TestAutoScrollToggle(t *testing.T) {
 		t.Fatal("autoScroll should toggle back to true")
 	}
 
-	// autoScroll should reset to true on startRun
 	m.autoScroll = false
 	m.urlInput.SetValue("https://example.com/api")
 	m, _ = m.startRun()
 	if !m.autoScroll {
 		t.Fatal("autoScroll should reset to true on startRun")
+	}
+}
+
+func TestAutoScrollSelectionAdvances(t *testing.T) {
+	m := NewModel()
+	m.focus = focusResults
+	m.autoScroll = true
+	m.startRun()
+
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 10 * time.Millisecond}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if m.selected != 0 {
+		t.Fatalf("after first result, selected = %d (expected 0)", m.selected)
+	}
+
+	msg2 := resultMsg{Result: model.Result{Status: 200, Latency: 20 * time.Millisecond}}
+	updated2, _ := m.Update(msg2)
+	m = updated2.(Model)
+
+	if m.selected != 1 {
+		t.Fatalf("after second result with auto-scroll, selected = %d (expected 1)", m.selected)
+	}
+}
+
+func TestAutoScrollDoesNotAdvanceWhenScrolledAway(t *testing.T) {
+	m := NewModel()
+	m.focus = focusResults
+	m.autoScroll = true
+	m.results = []model.Result{
+		{Status: 200},
+		{Status: 200},
+		{Status: 200},
+	}
+	m.selected = 0
+
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 5 * time.Millisecond}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if m.selected != 0 {
+		t.Fatalf("selected should stay at 0 when scrolled away, got %d", m.selected)
+	}
+}
+
+func TestWindowSizeMsg(t *testing.T) {
+	m := NewModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = updated.(Model)
+	if m.width != 120 || m.height != 40 {
+		t.Fatalf("width/height = %d/%d", m.width, m.height)
+	}
+}
+
+func TestTickMsg_Idle(t *testing.T) {
+	m := NewModel()
+	m.running = false
+	updated, _ := m.Update(tickMsg(time.Now()))
+	m = updated.(Model)
+	if m.elapsed != 0 {
+		t.Fatal("elapsed should not update when not running")
+	}
+}
+
+func TestResultMsg_AutoScrollOffKeepsSelection(t *testing.T) {
+	m := NewModel()
+	m.focus = focusResults
+	m.autoScroll = false
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+	m.selected = 0
+
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 5 * time.Millisecond}}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	if m.selected != 0 {
+		t.Fatalf("selected should stay at 0 with auto-scroll off, got %d", m.selected)
+	}
+}
+
+func TestResultMsg_CapEnforced(t *testing.T) {
+	m := NewModel()
+	m.focus = focusResults
+	m.autoScroll = false
+
+	capResults := 10000
+	for i := 0; i < capResults+5; i++ {
+		msg := resultMsg{Result: model.Result{Status: 200, Latency: 1 * time.Millisecond}}
+		updated, _ := m.Update(msg)
+		m = updated.(Model)
+	}
+
+	if len(m.results) != capResults {
+		t.Fatalf("results capped at %d, got %d", capResults, len(m.results))
+	}
+}
+
+func TestRunFinishedMsg(t *testing.T) {
+	m := NewModel()
+	m.running = true
+	m.startedAt = time.Now().Add(-2 * time.Second)
+	m.status = "RUNNING"
+
+	updated, _ := m.Update(runFinishedMsg{})
+	m = updated.(Model)
+
+	if m.running {
+		t.Fatal("running should be false after runFinishedMsg")
+	}
+	if m.status != "COMPLETE" {
+		t.Fatalf("status = %q (expected COMPLETE)", m.status)
+	}
+}
+
+func TestCtrlC_WhileRunning(t *testing.T) {
+	m := NewModel()
+	m.running = true
+	m.cancel = func() {}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("ctrl+c should return a quit command")
+	}
+}
+
+func TestCtrlC_Idle(t *testing.T) {
+	m := NewModel()
+	m.running = false
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	_ = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("ctrl+c while idle should return a quit command")
+	}
+}
+
+func TestCtrlR_WhileRunning(t *testing.T) {
+	m := NewModel()
+	m.running = true
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = updated.(Model)
+
+	if cmd != nil {
+		t.Fatal("ctrl+r while running should be a no-op (nil cmd)")
+	}
+}
+
+func TestCtrlX_Cancel(t *testing.T) {
+	m := NewModel()
+	m.running = true
+	m.cancel = func() {}
+	m.status = "RUNNING"
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = updated.(Model)
+
+	if m.status != "CANCELLED" {
+		t.Fatalf("status = %q (expected CANCELLED)", m.status)
+	}
+}
+
+func TestEsc_FromBodyFocus(t *testing.T) {
+	m := NewModel()
+	m.showPayload = true
+	m.focus = focusBody
+	m.headers = append(m.headers, newHeaderRow())
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.focus != focusHeaders {
+		t.Fatalf("focus = %v (expected focusHeaders)", m.focus)
+	}
+}
+
+func TestEsc_FromInspector(t *testing.T) {
+	m := NewModel()
+	m.inspector = true
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.inspector {
+		t.Fatal("esc should close the inspector")
+	}
+}
+
+func TestInit(t *testing.T) {
+	m := NewModel()
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init should return a non-nil command")
+	}
+}
+
+func TestConcurrency_ParseInvalid(t *testing.T) {
+	m := NewModel()
+	m.ccInput.SetValue("abc")
+	if got := m.concurrency(); got != 10 {
+		t.Fatalf("invalid concurrency should fallback to default, got %d", got)
+	}
+
+	m.ccInput.SetValue("")
+	if got := m.concurrency(); got != 10 {
+		t.Fatalf("empty concurrency should fallback to default, got %d", got)
+	}
+
+	m.ccInput.SetValue("7")
+	if got := m.concurrency(); got != 7 {
+		t.Fatalf("valid concurrency should be 7, got %d", got)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tt := []struct {
+		duration time.Duration
+		expected string
+	}{
+		{0, "0.00s"},
+		{-1 * time.Nanosecond, "0.00s"},
+		{500 * time.Millisecond, "0.50s"},
+		{1 * time.Second, "1.00s"},
+		{90 * time.Second, "1m 30s"},
+		{120 * time.Second, "2m 0s"},
+		{150 * time.Second, "2m 30s"},
+	}
+
+	for _, tc := range tt {
+		got := formatDuration(tc.duration)
+		if got != tc.expected {
+			t.Errorf("formatDuration(%v) = %q (expected %q)", tc.duration, got, tc.expected)
+		}
+	}
+}
+
+func TestHeaderMap(t *testing.T) {
+	m := NewModel()
+	m.headers = append(m.headers, headerRow{})
+	m.headers[0].Key.SetValue("Content-Type")
+	m.headers[0].Value.SetValue("application/json")
+	m.headers = append(m.headers, headerRow{})
+	m.headers[1].Key.SetValue("")
+	m.headers[1].Value.SetValue("should-skip")
+
+	hm := m.headerMap()
+	if len(hm) != 1 {
+		t.Fatalf("headerMap should have 1 entry (empty key skipped), got %d", len(hm))
+	}
+	if hm["Content-Type"] != "application/json" {
+		t.Fatalf("Content-Type = %q", hm["Content-Type"])
+	}
+}
+
+func TestClamp(t *testing.T) {
+	if got := clamp(5, 0, 10); got != 5 {
+		t.Fatalf("clamp(5, 0, 10) = %d", got)
+	}
+	if got := clamp(-5, 0, 10); got != 0 {
+		t.Fatalf("clamp(-5, 0, 10) = %d", got)
+	}
+	if got := clamp(15, 0, 10); got != 10 {
+		t.Fatalf("clamp(15, 0, 10) = %d", got)
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,16 +3,17 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 const (
-	colorBg      = "#09090b"
-	colorPanel   = "#111113"
-	colorBorder  = "#27272a"
-	colorText    = "#d4d4d8"
-	colorMuted   = "#71717a"
-	colorCyan    = "#22d3ee"
-	colorGreen   = "#34d399"
-	colorAmber   = "#fbbf24"
-	colorRose    = "#fb7185"
-	colorFuchsia = "#e879f9"
+	colorBg       = "#09090b"
+	colorPanel    = "#111113"
+	colorElevated = "#18181b"
+	colorBorder   = "#27272a"
+	colorText     = "#d4d4d8"
+	colorMuted    = "#71717a"
+	colorCyan     = "#22d3ee"
+	colorGreen    = "#34d399"
+	colorAmber    = "#fbbf24"
+	colorRose     = "#fb7185"
+	colorFuchsia  = "#e879f9"
 )
 
 var (
@@ -35,10 +36,6 @@ var (
 	mutedStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorMuted))
 
-	monoStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(colorMuted)).
-			Bold(true)
-
 	cyanStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorCyan)).
 			Bold(true)
@@ -49,18 +46,19 @@ var (
 			Background(lipgloss.Color(colorPanel)).
 			Padding(1, 2)
 
-	metricStyle = lipgloss.NewStyle().
-			Border(lipgloss.NormalBorder(), false, false, false, true).
-			BorderForeground(lipgloss.Color(colorBorder)).
-			Foreground(lipgloss.Color(colorText)).
-			PaddingLeft(1)
-
 	sectionTitleStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorCyan)).
 				Bold(true)
 
-	footerStyle = lipgloss.NewStyle().
+	separatorBorder = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colorBorder))
+
+	labelStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorMuted))
+
+	metricValueStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colorText)).
+			Bold(true)
 
 	emptyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorMuted)).
@@ -119,20 +117,23 @@ func runButtonStyle(running bool) lipgloss.Style {
 		Align(lipgloss.Center)
 }
 
-func tabStyle(active bool) lipgloss.Style {
-	style := lipgloss.NewStyle().
+func pillStyle(active bool) lipgloss.Style {
+	if active {
+		return lipgloss.NewStyle().
+			Padding(0, 3).
+			Foreground(lipgloss.Color("#ffffff")).
+			Background(lipgloss.Color(colorBorder)).
+			Bold(true)
+	}
+	return lipgloss.NewStyle().
 		Padding(0, 3).
 		Foreground(lipgloss.Color(colorMuted))
-	if active {
-		style = style.Foreground(lipgloss.Color("#ffffff")).Background(lipgloss.Color("#27272a")).Bold(true)
-	}
-	return style
 }
 
 func rowStyle(selected bool) lipgloss.Style {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color(colorText))
 	if selected {
-		style = style.Foreground(lipgloss.Color(colorCyan)).Background(lipgloss.Color("#18181b"))
+		style = style.Foreground(lipgloss.Color(colorCyan)).Background(lipgloss.Color(colorElevated))
 	}
 	return style
 }
@@ -158,7 +159,7 @@ func methodColor(name string) string {
 	case "PATCH":
 		return colorFuchsia
 	default:
-		return colorMuted // HEAD, OPTIONS
+		return colorMuted
 	}
 }
 
@@ -173,4 +174,20 @@ func methodStyle(name string, focused bool) lipgloss.Style {
 		s = s.Foreground(lipgloss.Color(methodColor(name)))
 	}
 	return s
+}
+
+func statusColor(status int) string {
+	if status == 0 {
+		return colorRose
+	}
+	if status >= 200 && status < 300 {
+		return colorGreen
+	}
+	if status >= 300 && status < 400 {
+		return colorCyan
+	}
+	if status >= 400 {
+		return colorRose
+	}
+	return colorMuted
 }

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -1,0 +1,166 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMethodColor(t *testing.T) {
+	tt := []struct {
+		method string
+		color  string
+	}{
+		{"GET", colorCyan},
+		{"POST", colorGreen},
+		{"PUT", colorAmber},
+		{"DELETE", colorRose},
+		{"PATCH", colorFuchsia},
+		{"HEAD", colorMuted},
+		{"OPTIONS", colorMuted},
+	}
+
+	for _, tc := range tt {
+		got := methodColor(tc.method)
+		if got != tc.color {
+			t.Errorf("methodColor(%q) = %q (expected %q)", tc.method, got, tc.color)
+		}
+	}
+}
+
+func TestMethodStyle(t *testing.T) {
+	s := methodStyle("GET", false)
+	rendered := s.Render("GET")
+	if !strings.Contains(rendered, "GET") {
+		t.Fatal("methodStyle should contain the method name")
+	}
+
+	sFocused := methodStyle("POST", true)
+	renderedFocused := sFocused.Render("POST")
+	if !strings.Contains(renderedFocused, "POST") {
+		t.Fatal("focused methodStyle should contain the method name")
+	}
+
+	sDefault := methodStyle("HEAD", false)
+	renderedDefault := sDefault.Render("HEAD")
+	if !strings.Contains(renderedDefault, "HEAD") {
+		t.Fatal("default methodStyle should contain HEAD")
+	}
+}
+
+func TestControlStyle(t *testing.T) {
+	unfocused := controlStyle(false)
+	rendered := unfocused.Render("test")
+	if !strings.Contains(rendered, "test") {
+		t.Fatal("controlStyle should render content")
+	}
+
+	focused := controlStyle(true)
+	renderedFocused := focused.Render("test")
+	if !strings.Contains(renderedFocused, "test") {
+		t.Fatal("focused controlStyle should render content")
+	}
+}
+
+func TestRunButtonStyle(t *testing.T) {
+	idle := runButtonStyle(false)
+	rendered := idle.Render("RUN")
+	if !strings.Contains(rendered, "RUN") {
+		t.Fatal("idle run button should contain RUN")
+	}
+
+	running := runButtonStyle(true)
+	renderedRunning := running.Render("CANCEL")
+	if !strings.Contains(renderedRunning, "CANCEL") {
+		t.Fatal("running button should contain CANCEL")
+	}
+}
+
+func TestPillStyle(t *testing.T) {
+	active := pillStyle(true)
+	rendered := active.Render("Timeline")
+	if !strings.Contains(rendered, "Timeline") {
+		t.Fatal("active pill should contain 'Timeline'")
+	}
+
+	inactive := pillStyle(false)
+	renderedInactive := inactive.Render("Live Logs")
+	if !strings.Contains(renderedInactive, "Live Logs") {
+		t.Fatal("inactive pill should contain 'Live Logs'")
+	}
+}
+
+func TestRowStyle(t *testing.T) {
+	selected := rowStyle(true)
+	rendered := selected.Render("test")
+	if !strings.Contains(rendered, "test") {
+		t.Fatal("selected row should contain text")
+	}
+
+	normal := rowStyle(false)
+	renderedNormal := normal.Render("test")
+	if !strings.Contains(renderedNormal, "test") {
+		t.Fatal("normal row should contain text")
+	}
+}
+
+func TestErrorRowStyle(t *testing.T) {
+	selected := errorRowStyle(true)
+	rendered := selected.Render("error")
+	if !strings.Contains(rendered, "error") {
+		t.Fatal("selected error row should contain text")
+	}
+
+	normal := errorRowStyle(false)
+	renderedNormal := normal.Render("error")
+	if !strings.Contains(renderedNormal, "error") {
+		t.Fatal("normal error row should contain text")
+	}
+}
+
+func TestBodyStyle(t *testing.T) {
+	focused := bodyStyle(true)
+	rendered := focused.Render("body")
+	if !strings.Contains(rendered, "body") {
+		t.Fatal("focused bodyStyle should contain text")
+	}
+
+	unfocused := bodyStyle(false)
+	renderedUnfocused := unfocused.Render("body")
+	if !strings.Contains(renderedUnfocused, "body") {
+		t.Fatal("unfocused bodyStyle should contain text")
+	}
+}
+
+func TestInputStyle(t *testing.T) {
+	focused := inputStyle(true)
+	rendered := focused.Render("input")
+	if !strings.Contains(rendered, "input") {
+		t.Fatal("focused inputStyle should contain text")
+	}
+
+	unfocused := inputStyle(false)
+	renderedUnfocused := unfocused.Render("input")
+	if !strings.Contains(renderedUnfocused, "input") {
+		t.Fatal("unfocused inputStyle should contain text")
+	}
+}
+
+func TestStatusColor(t *testing.T) {
+	tt := []struct {
+		status int
+		color  string
+	}{
+		{0, colorRose},
+		{200, colorGreen},
+		{301, colorCyan},
+		{404, colorRose},
+		{500, colorRose},
+	}
+
+	for _, tc := range tt {
+		got := statusColor(tc.status)
+		if got != tc.color {
+			t.Errorf("statusColor(%d) = %q (expected %q)", tc.status, got, tc.color)
+		}
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -19,31 +19,37 @@ func (m Model) View() string {
 		return "Pulse is starting..."
 	}
 
-	width := clamp(m.width, 72, 140)
+	width := max(72, m.width)
 	innerWidth := width - 4
 
 	header := m.renderHeader(innerWidth)
 	command := m.renderCommand(innerWidth)
-	metricStrip := m.renderMetrics(innerWidth)
+	metricsStrip := m.renderMetrics(innerWidth)
+	sparkline := m.renderSparkline(innerWidth)
+
 	payload := ""
 	if m.showPayload {
 		payload = m.renderPayload(innerWidth)
 	}
 
-	sparkline := m.renderSparkline(innerWidth)
-
-	used := lipgloss.Height(header) + lipgloss.Height(command) + lipgloss.Height(metricStrip) + lipgloss.Height(sparkline) + lipgloss.Height(payload) + 5
-	workspaceHeight := max(8, m.height-used)
-	workspace := m.renderWorkspace(innerWidth, workspaceHeight)
-	footerText := "tab/⇧tab focus  ctrl+r run  ctrl+x cancel  ctrl+a scroll  [/] tabs  ↑↓ select  enter inspect  esc back  q quit"
-	if !m.running && len(m.results) > 0 {
-		s := metrics.Compute(m.results, displayElapsed(m))
-		footerText = fmt.Sprintf("%s  |  %d results  p99 %s  %d errors",
-			footerText, s.Total, formatDuration(s.P99), s.Total-s.Successes)
+	fixed := lipgloss.Height(header)
+	fixed += lipgloss.Height(command)
+	fixed += lipgloss.Height(metricsStrip)
+	if sparkline != "" {
+		fixed += lipgloss.Height(sparkline)
 	}
-	footer := footerStyle.Width(innerWidth).Render(footerText)
+	if payload != "" {
+		fixed += lipgloss.Height(payload)
+	}
 
-	parts := []string{header, command, metricStrip}
+	footer := m.renderFooter(innerWidth)
+	footerHeight := lipgloss.Height(footer)
+
+	available := m.height - 2 - fixed - footerHeight - 4
+	workspaceHeight := max(8, available)
+	workspace := m.renderWorkspace(innerWidth, workspaceHeight)
+
+	parts := []string{header, command, metricsStrip}
 	if sparkline != "" {
 		parts = append(parts, sparkline)
 	}
@@ -73,75 +79,130 @@ func (m Model) renderHeader(width int) string {
 	if m.running && m.dotGlow {
 		dot = statusDotGlowStyle.Render("●")
 	}
+
 	left := lipgloss.JoinHorizontal(lipgloss.Center,
-		dot,
-		" ",
+		dot, " ",
 		titleStyle.Render("Pulse"),
 		" ",
 		mutedStyle.Render("terminal"),
 	)
-	right := monoStyle.Render(state)
-	gap := strings.Repeat(" ", max(1, width-lipgloss.Width(left)-lipgloss.Width(right)))
-	return lipgloss.JoinHorizontal(lipgloss.Center, left, gap, right)
+
+	line := lipgloss.JoinHorizontal(lipgloss.Center,
+		left,
+		lipgloss.NewStyle().Width(width-lipgloss.Width(left)-lipgloss.Width(state)).Render(""),
+		state,
+	)
+
+	separator := separatorBorder.Render(strings.Repeat("─", width))
+	return lipgloss.JoinVertical(lipgloss.Left, line, separator)
 }
 
 func (m Model) renderCommand(width int) string {
-	method := methodStyle(runconfig.AllowedMethods()[m.methodIndex], m.focus == focusMethod).Width(10).Render(runconfig.AllowedMethods()[m.methodIndex])
-	url := inputStyle(m.focus == focusURL).Width(max(20, width-54)).Render(truncate(m.urlInput.Value(), max(18, width-56)))
-	cc := controlStyle(m.focus == focusConcurrency).Width(8).Render(fmt.Sprintf("CC %d", m.concurrency()))
+	methodName := runconfig.AllowedMethods()[m.methodIndex]
+	method := methodStyle(methodName, m.focus == focusMethod).Render(methodName)
+	methodBox := lipgloss.NewStyle().Width(10).Render(method)
 
-	payloadLabel := "PAYLOAD OFF"
+	urlBox := inputStyle(m.focus == focusURL).
+		Width(max(20, width-56)).
+		Render(truncate(m.urlInput.Value(), max(18, width-58)))
+
+	ccBox := controlStyle(m.focus == focusConcurrency).
+		Width(8).
+		Render(fmt.Sprintf("CC %d", m.concurrency()))
+
+	payloadLabel := "PAYLOAD"
 	if m.showPayload {
-		payloadLabel = "PAYLOAD ON"
+		payloadLabel = "PAYLOAD·ON"
 	}
-	payload := controlStyle(m.focus == focusPayload).Width(13).Render(payloadLabel)
+	payloadBox := controlStyle(m.focus == focusPayload).
+		Width(11).
+		Render(payloadLabel)
 
-	runLabel := "RUN"
+	runLabel := "▶ RUN"
 	if m.running {
-		runLabel = "CANCEL"
+		runLabel = "◼ CANCEL"
 	}
-	run := runButtonStyle(m.running).Width(8).Render(runLabel)
+	runBox := runButtonStyle(m.running).Width(10).Render(runLabel)
 
-	row := lipgloss.JoinHorizontal(lipgloss.Top, method, " ", url, " ", cc, " ", payload, " ", run)
+	divider := separatorBorder.Render("│")
+
+	row := lipgloss.JoinHorizontal(lipgloss.Center,
+		methodBox, " ", divider, " ",
+		urlBox, " ", divider, " ",
+		ccBox, " ", divider, " ",
+		payloadBox, " ", divider, " ",
+		runBox,
+	)
+
 	return panelStyle.Width(width).Render(row)
 }
 
 func (m Model) renderMetrics(width int) string {
 	summary := m.summary
-	segmentWidth := max(12, (width-6)/4)
+	segWidth := max(14, (width-6)/4)
 
 	target := m.concurrency()
-	barWidth := segmentWidth - 6
-	if barWidth < 2 {
-		barWidth = 2
-	}
-	filled := 0
+	barWidth := max(4, segWidth-8)
+	var bar string
 	if target > 0 {
-		filled = summary.Total * barWidth / target
+		filled := summary.Total * barWidth / target
 		if filled > barWidth {
 			filled = barWidth
 		}
+		bar = strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
+		bar += fmt.Sprintf(" %d/%d", summary.Total, target)
+	} else {
+		bar = fmt.Sprintf("%d", summary.Total)
 	}
-	bar := strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled)
-	requests := metricStyle.Width(segmentWidth).Render(fmt.Sprintf("REQUESTS\n%s %d/%d", bar, summary.Total, target))
+	requests := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("REQUESTS"),
+		metricValueStyle.Render(bar),
+	)
 
 	successColor := colorAmber
 	if summary.SuccessRate >= 100 {
 		successColor = colorGreen
 	}
-	success := metricStyle.Foreground(lipgloss.Color(successColor)).Width(segmentWidth).Render(fmt.Sprintf("SUCCESS\n%d%%", summary.SuccessRate))
+	success := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("SUCCESS"),
+		lipgloss.NewStyle().Foreground(lipgloss.Color(successColor)).Bold(true).Render(fmt.Sprintf("%d%%", summary.SuccessRate)),
+	)
 
 	errors := summary.Total - summary.Successes
 	errColor := colorGreen
 	if errors > 0 {
 		errColor = colorRose
 	}
-	errSegment := metricStyle.Foreground(lipgloss.Color(errColor)).Width(segmentWidth).Render(fmt.Sprintf("ERRORS\n%d", errors))
+	rps := 0.0
+	if m.elapsed > 0 {
+		rps = float64(summary.Total) / m.elapsed.Seconds()
+	}
+	errorsRPS := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("ERRORS"),
+		lipgloss.JoinHorizontal(lipgloss.Left,
+			lipgloss.NewStyle().Foreground(lipgloss.Color(errColor)).Bold(true).Render(fmt.Sprintf("%d", errors)),
+			" ",
+			mutedStyle.Render(fmt.Sprintf("%.1f/s", rps)),
+		),
+	)
 
-	pSegment := metricStyle.Width(segmentWidth).Render(fmt.Sprintf("p50 %s  p90 %s\np99 %s",
-		formatDuration(summary.P50), formatDuration(summary.P90), formatDuration(summary.P99)))
+	lat := lipgloss.JoinVertical(lipgloss.Left,
+		labelStyle.Render("LATENCY"),
+		metricValueStyle.Render(fmt.Sprintf("%s/%s",
+			formatDuration(summary.P50),
+			formatDuration(summary.P99),
+		)),
+	)
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, requests, "  ", success, "  ", errSegment, "  ", pSegment)
+	row := lipgloss.JoinHorizontal(lipgloss.Top,
+		lipgloss.NewStyle().Width(segWidth).Render(requests), "  ",
+		lipgloss.NewStyle().Width(segWidth).Render(success), "  ",
+		lipgloss.NewStyle().Width(segWidth).Render(errorsRPS), "  ",
+		lipgloss.NewStyle().Width(segWidth).Render(lat),
+	)
+
+	separator := separatorBorder.Render(strings.Repeat("─", width))
+	return lipgloss.JoinVertical(lipgloss.Left, row, separator)
 }
 
 func (m Model) renderPayload(width int) string {
@@ -155,7 +216,7 @@ func (m Model) renderPayload(width int) string {
 		for i, header := range m.headers {
 			prefix := "  "
 			if m.focus == focusHeaders && i == m.selectedHead {
-				prefix = "> "
+				prefix = "▸ "
 			}
 			key := truncate(header.Key.Value(), leftWidth/2-4)
 			value := truncate(header.Value.Value(), leftWidth/2-4)
@@ -181,14 +242,16 @@ func (m Model) renderPayload(width int) string {
 }
 
 func (m Model) renderWorkspace(width int, height int) string {
-	tabs := m.renderTabs(width)
-	bodyHeight := max(4, height-lipgloss.Height(tabs)-2)
+	contentWidth := width - 6
+	tabs := m.renderTabs(contentWidth)
+	tabsHeight := lipgloss.Height(tabs)
+	bodyHeight := max(4, height-4-tabsHeight)
 
-	resultsWidth := width
+	resultsWidth := contentWidth
 	inspector := ""
-	if m.inspector && width >= 108 {
-		resultsWidth = width*58/100 - 1
-		inspector = m.renderInspector(width-resultsWidth-1, bodyHeight)
+	if m.inspector && contentWidth >= 108 {
+		resultsWidth = contentWidth*58/100 - 1
+		inspector = m.renderInspector(contentWidth-resultsWidth-1, bodyHeight)
 	}
 
 	var results string
@@ -202,33 +265,39 @@ func (m Model) renderWorkspace(width int, height int) string {
 	if inspector != "" {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, results, " ", inspector)
 	} else if m.inspector {
-		body = lipgloss.JoinVertical(lipgloss.Left, results, m.renderInspector(width, max(6, bodyHeight/2)))
+		body = lipgloss.JoinVertical(lipgloss.Left, results, m.renderInspector(contentWidth, max(6, bodyHeight/2)))
 	}
 
-	return panelStyle.Width(width).Height(height).Render(lipgloss.JoinVertical(lipgloss.Left, tabs, body))
+	return panelStyle.Width(width).Height(height).Render(
+		lipgloss.JoinVertical(lipgloss.Left, tabs, body),
+	)
 }
 
 func (m Model) renderTabs(width int) string {
-	timeline := tabStyle(m.activeTab == tabTimeline).Render("Timeline")
-	logs := tabStyle(m.activeTab == tabLogs).Render("Live Logs")
+	timeline := pillStyle(m.activeTab == tabTimeline).Render("Timeline")
+	logs := pillStyle(m.activeTab == tabLogs).Render("Live Logs")
 	indicator := ""
 	if !m.autoScroll {
 		indicator = mutedStyle.Render("  MANUAL")
 	}
-	return lipgloss.PlaceHorizontal(width-2, lipgloss.Center, lipgloss.JoinHorizontal(lipgloss.Top, timeline, logs, indicator))
+	return lipgloss.PlaceHorizontal(width, lipgloss.Center,
+		lipgloss.JoinHorizontal(lipgloss.Top, timeline, " ", logs, indicator),
+	)
 }
 
 func (m Model) renderTimeline(width int, height int) string {
 	if len(m.results) == 0 {
-		return emptyStyle.Width(width - 4).Height(height).Render("Awaiting execution...")
+		return emptyStyle.Width(width).Height(height).Render("Awaiting execution...")
 	}
 
-	lines := make([]string, 0, min(len(m.results), height))
-	start := max(0, len(m.results)-height)
-	for i := start; i < len(m.results); i++ {
+	maxStart := max(0, len(m.results)-height)
+	start := max(0, min(m.selected-height/2, maxStart))
+
+	lines := make([]string, 0, min(len(m.results)-start, height))
+	for i := start; i < len(m.results) && len(lines) < height; i++ {
 		result := m.results[i]
-		selected := m.focus == focusResults && i == m.selected
-		lines = append(lines, m.renderTimelineRow(i, result, m.summary.MaxLatency, width-4, selected))
+		sel := m.focus == focusResults && i == m.selected
+		lines = append(lines, m.renderTimelineRow(i, result, m.summary.MaxLatency, width, sel))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -236,30 +305,46 @@ func (m Model) renderTimeline(width int, height int) string {
 func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time.Duration, width int, selected bool) string {
 	status := resultStatus(result)
 	latency := formatDuration(result.Latency)
-	labelWidth := 18
-	barWidth := max(8, width-labelWidth-len(latency)-6)
-	filled := 1
+	method := result.RequestMethod
+	if method == "" {
+		method = runconfig.AllowedMethods()[m.methodIndex]
+	}
+
+	barWidth := max(6, width-38)
+	filled := 0
 	if maxLatency > 0 {
-		filled = max(1, int(float64(result.Latency)/float64(maxLatency)*float64(barWidth)))
+		filled = int(float64(result.Latency) / float64(maxLatency) * float64(barWidth))
+		if filled > barWidth {
+			filled = barWidth
+		}
 	}
-	bar := strings.Repeat("#", filled) + strings.Repeat("-", max(0, barWidth-filled))
-	line := fmt.Sprintf("%s %3d %-12s [%s] %8s", rowCursor(selected), index+1, status, bar, latency)
+
+	barColor := statusColor(result.Status)
+	bar := lipgloss.NewStyle().Foreground(lipgloss.Color(barColor)).Render(
+		strings.Repeat("█", filled) + strings.Repeat("░", barWidth-filled),
+	)
+
+	line := fmt.Sprintf("%s %3d %-4s %-12s %s %s",
+		rowCursor(selected), index+1, method, status, bar, latency)
+
 	if result.Status >= 400 || result.Status == 0 {
-		return errorRowStyle(selected).Render(truncate(line, width))
+		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
 	}
-	return rowStyle(selected).Render(truncate(line, width))
+	return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
 }
 
 func (m Model) renderLogs(width int, height int) string {
 	if len(m.results) == 0 {
-		return emptyStyle.Width(width - 4).Height(height).Render("No logs yet.")
+		return emptyStyle.Width(width).Height(height).Render("No logs yet.")
 	}
 
-	lines := make([]string, 0, min(len(m.results), height))
-	start := max(0, len(m.results)-height)
-	for i := start; i < len(m.results); i++ {
+	maxStart := max(0, len(m.results)-height)
+	start := max(0, min(m.selected-height/2, maxStart))
+
+	lines := make([]string, 0, min(len(m.results)-start, height))
+	for i := start; i < len(m.results) && len(lines) < height; i++ {
 		result := m.results[i]
-		selected := m.focus == focusResults && i == m.selected
+		sel := m.focus == focusResults && i == m.selected
 		status := resultStatus(result)
 		method := result.RequestMethod
 		if method == "" {
@@ -269,11 +354,12 @@ func (m Model) renderLogs(width int, height int) string {
 		if reqURL == "" {
 			reqURL = m.urlInput.Value()
 		}
-		line := fmt.Sprintf("%s %3d %-6s %-10s %-8s %s", rowCursor(selected), i+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
+		line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
+			rowCursor(sel), i+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
 		if result.Status >= 400 || result.Status == 0 {
-			lines = append(lines, errorRowStyle(selected).Render(truncate(line, width-4)))
+			lines = append(lines, strings.TrimSpace(errorRowStyle(sel).Render(truncate(line, width))))
 		} else {
-			lines = append(lines, rowStyle(selected).Render(truncate(line, width-4)))
+			lines = append(lines, strings.TrimSpace(rowStyle(sel).Render(truncate(line, width))))
 		}
 	}
 	return strings.Join(lines, "\n")
@@ -285,8 +371,19 @@ func (m Model) renderInspector(width int, height int) string {
 	}
 
 	result := m.results[m.selected]
+	method := result.RequestMethod
+	if method == "" {
+		method = runconfig.AllowedMethods()[m.methodIndex]
+	}
+	reqURL := result.RequestURL
+	if reqURL == "" {
+		reqURL = m.urlInput.Value()
+	}
+
 	lines := []string{
 		sectionTitleStyle.Render("INSPECTOR"),
+		fmt.Sprintf("  %s %s", methodStyle(method, false).Render(method), truncate(reqURL, width-12)),
+		"",
 		fmt.Sprintf("Status:  %s", resultStatus(result)),
 		fmt.Sprintf("Latency: %s", formatDuration(result.Latency)),
 	}
@@ -313,21 +410,46 @@ func (m Model) renderInspector(width int, height int) string {
 	if body == "" {
 		body = mutedStyle.Render("No body captured.")
 	}
-	for _, line := range strings.Split(body, "\n") {
-		lines = append(lines, truncate(line, width-4))
+	bodyLines := strings.Split(body, "\n")
+	for i, bline := range bodyLines {
 		if len(lines) >= height-2 {
+			if i < len(bodyLines)-1 {
+				lines = append(lines, mutedStyle.Render("... (truncated)"))
+			}
 			break
 		}
+		lines = append(lines, truncate(bline, width-4))
 	}
 
 	return panelStyle.Width(width).Height(height).Render(strings.Join(lines, "\n"))
 }
 
-func displayElapsed(m Model) time.Duration {
-	if m.running {
-		return m.elapsed
+func (m Model) renderFooter(width int) string {
+	left := "tab/⇧tab focus  ctrl+r run  ctrl+x cancel  ctrl+a scroll  [/] tabs  ↑↓ select  enter inspect  esc back  q quit"
+
+	right := ""
+	if !m.running && len(m.results) > 0 {
+		s := metrics.Compute(m.results, m.elapsed)
+		right = fmt.Sprintf("%d results  p99 %s  %d errors",
+			s.Total, formatDuration(s.P99), s.Total-s.Successes)
 	}
-	if m.elapsed > 0 {
+
+	var line string
+	if right != "" {
+		leftWidth := max(40, width-lipgloss.Width(mutedStyle.Render(right))-4)
+		line = lipgloss.JoinHorizontal(lipgloss.Center,
+			mutedStyle.Width(leftWidth).Render(truncate(left, leftWidth)),
+			mutedStyle.Render(right),
+		)
+	} else {
+		line = mutedStyle.Render(truncate(left, width))
+	}
+
+	return separatorBorder.Render(strings.Repeat("─", width)) + "\n" + line
+}
+
+func displayElapsed(m Model) time.Duration {
+	if m.running || m.elapsed > 0 {
 		return m.elapsed
 	}
 	return 0
@@ -337,16 +459,19 @@ func (m Model) renderSparkline(width int) string {
 	if m.latencyLen == 0 {
 		return ""
 	}
-	label := mutedStyle.Render(" LATENCY")
+
+	label := labelStyle.Render(" LATENCY SPARKLINE")
 	labelWidth := lipgloss.Width(label)
 	barWidth := width - labelWidth - 2
 	if barWidth < 4 {
 		barWidth = 4
 	}
+
 	count := m.latencyLen
 	if count > barWidth {
 		count = barWidth
 	}
+
 	maxLat := time.Duration(0)
 	for i := 0; i < count; i++ {
 		idx := (m.latencyHead - count + i + latencyRingSize) % latencyRingSize
@@ -354,6 +479,7 @@ func (m Model) renderSparkline(width int) string {
 			maxLat = m.latencyRing[idx]
 		}
 	}
+
 	var sb strings.Builder
 	for i := 0; i < count; i++ {
 		idx := (m.latencyHead - count + i + latencyRingSize) % latencyRingSize
@@ -375,7 +501,10 @@ func (m Model) renderSparkline(width int) string {
 		}
 		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(dotColor)).Render(string(sparklineChars[level])))
 	}
-	return fmt.Sprintf(" %s%s", sb.String(), label)
+
+	separator := separatorBorder.Render(strings.Repeat("─", width))
+	row := fmt.Sprintf("%s%s", sb.String(), label)
+	return lipgloss.JoinVertical(lipgloss.Left, row, separator)
 }
 
 func resultStatus(result model.Result) string {
@@ -383,6 +512,8 @@ func resultStatus(result model.Result) string {
 		return "ERR"
 	}
 	switch {
+	case result.Status >= 100 && result.Status < 200:
+		return fmt.Sprintf("%d Info", result.Status)
 	case result.Status >= 200 && result.Status < 300:
 		return fmt.Sprintf("%d OK", result.Status)
 	case result.Status >= 300 && result.Status < 400:
@@ -396,7 +527,7 @@ func resultStatus(result model.Result) string {
 
 func rowCursor(selected bool) string {
 	if selected {
-		return ">"
+		return "▸"
 	}
 	return " "
 }
@@ -413,5 +544,5 @@ func truncate(value string, width int) string {
 	if width <= 1 {
 		return string(runes[:width])
 	}
-	return string(runes[:width-1]) + "..."
+	return string(runes[:width-1]) + "…"
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,0 +1,462 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/divijg19/Pulse/internal/model"
+	"github.com/divijg19/Pulse/internal/runconfig"
+)
+
+func contains(t *testing.T, s, substr string) bool {
+	t.Helper()
+	return strings.Contains(s, substr)
+}
+
+func TestView_Idle(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	out := m.View()
+	if !contains(t, out, "Pulse") {
+		t.Fatal("View should contain 'Pulse'")
+	}
+	if !contains(t, out, "SYSTEM READY") {
+		t.Fatal("View should contain 'SYSTEM READY'")
+	}
+	if !contains(t, out, "Awaiting execution...") {
+		t.Fatal("View should contain 'Awaiting execution...'")
+	}
+}
+
+func TestView_Running(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	m.running = true
+	m.status = "RUNNING"
+	m.startedAt = time.Now().Add(-2 * time.Second)
+	m.elapsed = 2 * time.Second
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+	}
+	out := m.View()
+	if !contains(t, out, "ELAPSED") {
+		t.Fatal("running view should show elapsed time")
+	}
+	if !contains(t, out, "RPS") {
+		t.Fatal("running view should show RPS")
+	}
+}
+
+func TestView_EmptyState(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	out := m.View()
+	if !contains(t, out, "Awaiting execution...") {
+		t.Fatal("empty view should show 'Awaiting execution...'")
+	}
+}
+
+func TestRenderCommand(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderCommand(96)
+	if !contains(t, out, "GET") {
+		t.Fatal("command should contain 'GET'")
+	}
+	if !contains(t, out, "CC") {
+		t.Fatal("command should contain 'CC'")
+	}
+	if !contains(t, out, "RUN") {
+		t.Fatal("command should contain 'RUN'")
+	}
+	if !contains(t, out, "PAYLOAD") {
+		t.Fatal("command should contain 'PAYLOAD'")
+	}
+}
+
+func TestRenderCommand_Running(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	out := m.renderCommand(96)
+	if !contains(t, out, "CANCEL") {
+		t.Fatal("running command should contain 'CANCEL'")
+	}
+}
+
+func TestRenderCommand_Dividers(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderCommand(96)
+	count := strings.Count(out, "│")
+	if count < 3 {
+		t.Fatalf("command should have at least 3 vertical dividers, got %d", count)
+	}
+}
+
+func TestRenderMetrics(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.summary.Total = 50
+	m.summary.Successes = 45
+	m.summary.SuccessRate = 90
+	m.summary.P50 = 100 * time.Millisecond
+	m.summary.P99 = 500 * time.Millisecond
+	m.elapsed = 5 * time.Second
+
+	out := m.renderMetrics(96)
+	if !contains(t, out, "REQUESTS") {
+		t.Fatal("metrics should contain 'REQUESTS'")
+	}
+	if !contains(t, out, "SUCCESS") {
+		t.Fatal("metrics should contain 'SUCCESS'")
+	}
+	if !contains(t, out, "ERRORS") {
+		t.Fatal("metrics should contain 'ERRORS'")
+	}
+	if !contains(t, out, "LATENCY") {
+		t.Fatal("metrics should contain 'LATENCY'")
+	}
+	if !contains(t, out, "90%") {
+		t.Fatal("metrics should show '90%' success rate")
+	}
+	if !contains(t, out, "0.10s") {
+		t.Fatal("metrics should show p50 latency")
+	}
+}
+
+func TestRenderMetrics_Zero(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderMetrics(96)
+	if !contains(t, out, "REQUESTS") {
+		t.Fatal("zero metrics should still show 'REQUESTS'")
+	}
+}
+
+func TestRenderPayload_Open(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.showPayload = true
+	m.headers = append(m.headers, newHeaderRow())
+	m.headers[0].Key.SetValue("Content-Type")
+	m.headers[0].Value.SetValue("application/json")
+
+	out := m.renderPayload(96)
+	if !contains(t, out, "HEADERS") {
+		t.Fatal("payload should contain 'HEADERS'")
+	}
+	if !contains(t, out, "BODY") {
+		t.Fatal("payload should contain 'BODY'")
+	}
+	if !contains(t, out, "Content-Type") {
+		t.Fatal("payload should contain header key")
+	}
+	if !contains(t, out, "application/json") {
+		t.Fatal("payload should contain header value")
+	}
+}
+
+func TestRenderTabs(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderTabs(94)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("tabs should contain 'Timeline'")
+	}
+	if !contains(t, out, "Live Logs") {
+		t.Fatal("tabs should contain 'Live Logs'")
+	}
+}
+
+func TestRenderTabs_Manual(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.autoScroll = false
+	out := m.renderTabs(94)
+	if !contains(t, out, "MANUAL") {
+		t.Fatal("tabs should show 'MANUAL' when autoScroll is off")
+	}
+}
+
+func TestRenderTimeline_Empty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Awaiting execution...") {
+		t.Fatal("empty timeline should show 'Awaiting execution...'")
+	}
+}
+
+func TestRenderTimeline_Rows(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+		{Status: 404, Latency: 50 * time.Millisecond},
+	}
+	m.summary.MaxLatency = 100 * time.Millisecond
+	m.focus = focusResults
+	m.selected = 0
+
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "200") {
+		t.Fatal("timeline should show status code 200")
+	}
+	if !contains(t, out, "404") {
+		t.Fatal("timeline should show status code 404")
+	}
+	if !contains(t, out, "0.10s") {
+		t.Fatal("timeline should show latency")
+	}
+}
+
+func TestRenderLogs_Empty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "No logs yet.") {
+		t.Fatal("empty logs should show 'No logs yet.'")
+	}
+}
+
+func TestRenderLogs_Rows(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.urlInput.SetValue("https://example.com/api")
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond, RequestMethod: "GET", RequestURL: "https://example.com/api"},
+		{Status: 500, Latency: 50 * time.Millisecond, RequestMethod: "POST", RequestURL: "https://example.com/error"},
+	}
+	m.summary.MaxLatency = 100 * time.Millisecond
+	m.focus = focusResults
+	m.selected = 0
+
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "GET") {
+		t.Fatal("logs should show method 'GET'")
+	}
+	if !contains(t, out, "POST") {
+		t.Fatal("logs should show method 'POST'")
+	}
+	if !contains(t, out, "200") {
+		t.Fatal("logs should show status 200")
+	}
+	if !contains(t, out, "500") {
+		t.Fatal("logs should show status 500")
+	}
+	if !contains(t, out, "0.10s") {
+		t.Fatal("logs should show latency")
+	}
+}
+
+func TestRenderInspector_NoSelection(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderInspector(40, 20)
+	if !contains(t, out, "No result selected.") {
+		t.Fatal("inspector with no selection should show 'No result selected.'")
+	}
+}
+
+func TestRenderInspector_WithResult(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			ResponseBody: `{"ok": true}`,
+		},
+	}
+
+	out := m.renderInspector(40, 20)
+	if !contains(t, out, "INSPECTOR") {
+		t.Fatal("inspector should show 'INSPECTOR'")
+	}
+	if !contains(t, out, "200") {
+		t.Fatal("inspector should show status")
+	}
+	if !contains(t, out, "0.10s") {
+		t.Fatal("inspector should show latency")
+	}
+	if !contains(t, out, "Content-Type") {
+		t.Fatal("inspector should show response headers")
+	}
+	if !contains(t, out, "application/json") {
+		t.Fatal("inspector should show header values")
+	}
+}
+
+func TestRenderSparkline_Empty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderSparkline(96)
+	if out != "" {
+		t.Fatal("sparkline should be empty when no data")
+	}
+}
+
+func TestRenderSparkline_WithData(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.latencyLen = 5
+	m.latencyRing[0] = 10 * time.Millisecond
+	m.latencyRing[1] = 20 * time.Millisecond
+	m.latencyRing[2] = 50 * time.Millisecond
+	m.latencyRing[3] = 100 * time.Millisecond
+	m.latencyRing[4] = 200 * time.Millisecond
+	m.latencyHead = 5
+
+	out := m.renderSparkline(96)
+	if !contains(t, out, "LATENCY SPARKLINE") {
+		t.Fatal("sparkline should show 'LATENCY SPARKLINE' label")
+	}
+}
+
+func TestResultStatus(t *testing.T) {
+	tt := []struct {
+		status   int
+		expected string
+	}{
+		{0, "ERR"},
+		{200, "200 OK"},
+		{201, "201 OK"},
+		{301, "301 Redirect"},
+		{400, "400"},
+		{404, "404"},
+		{500, "500"},
+		{101, "101 Info"},
+		{199, "199 Info"},
+		{302, "302 Redirect"},
+	}
+
+	for _, tc := range tt {
+		result := model.Result{Status: tc.status}
+		got := resultStatus(result)
+		if got != tc.expected {
+			t.Errorf("resultStatus(%d) = %q (expected %q)", tc.status, got, tc.expected)
+		}
+	}
+}
+
+func TestRowCursor(t *testing.T) {
+	if got := rowCursor(true); got != "▸" {
+		t.Errorf("selected cursor = %q", got)
+	}
+	if got := rowCursor(false); got != " " {
+		t.Errorf("unselected cursor = %q", got)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tt := []struct {
+		value string
+		width int
+		exp   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hell…"},
+		{"", 5, ""},
+		{"hello", 0, ""},
+		{"abc", 1, "a"},
+		{"hi\n there", 10, "hi  there"},
+	}
+
+	for _, tc := range tt {
+		got := truncate(tc.value, tc.width)
+		if got != tc.exp {
+			t.Errorf("truncate(%q, %d) = %q (expected %q)", tc.value, tc.width, got, tc.exp)
+		}
+	}
+}
+
+func TestDisplayElapsed(t *testing.T) {
+	m := NewModel()
+	m.elapsed = 5 * time.Second
+
+	m.running = false
+	if got := displayElapsed(m); got != 5*time.Second {
+		t.Fatalf("elapsed should be 5s when not running but has elapsed, got %v", got)
+	}
+
+	m.running = true
+	m.elapsed = 3 * time.Second
+	if got := displayElapsed(m); got != 3*time.Second {
+		t.Fatalf("elapsed should be 3s when running, got %v", got)
+	}
+
+	m.running = false
+	m.elapsed = 0
+	if got := displayElapsed(m); got != 0 {
+		t.Fatalf("elapsed should be 0 when idle, got %v", got)
+	}
+}
+
+func TestRenderFooter_Empty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderFooter(96)
+	if !contains(t, out, "ctrl+r") {
+		t.Fatal("footer should show 'ctrl+r' shortcut")
+	}
+	if !contains(t, out, "ctrl+x") {
+		t.Fatal("footer should show 'ctrl+x' shortcut")
+	}
+}
+
+func TestRenderFooter_WithResults(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = false
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+		{Status: 200, Latency: 20 * time.Millisecond},
+	}
+	m.elapsed = 2 * time.Second
+
+	out := m.renderFooter(96)
+	if !contains(t, out, "2 results") {
+		t.Fatal("footer should show result count")
+	}
+	if !contains(t, out, "p99") {
+		t.Fatal("footer should show p99 latency")
+	}
+}
+
+func TestMethodFallback(t *testing.T) {
+	m := NewModel()
+	m.methodIndex = 0
+	m.urlInput.SetValue("https://example.com")
+
+	result := model.Result{Status: 200, Latency: 10 * time.Millisecond}
+
+	if result.RequestMethod != "" {
+		t.Fatal("test setup: RequestMethod should be empty")
+	}
+	if result.RequestURL != "" {
+		t.Fatal("test setup: RequestURL should be empty")
+	}
+
+	_ = resultStatus(result)
+	_ = formatDuration(result.Latency)
+	_ = fmt.Sprintf("%s", runconfig.AllowedMethods()[m.methodIndex])
+	_ = truncate(m.urlInput.Value(), 30)
+}
+
+func TestVersion(t *testing.T) {
+	out := "Pulse terminal"
+	if !strings.Contains(out, "Pulse") {
+		t.Fatal("should contain Pulse")
+	}
+}


### PR DESCRIPTION
Visual redesign inspired by WebUI, distinct TUI identity:
- Pill-shaped tabs with active fill (instead of flat colored text)
- Vertical dividers between command bar sections (method | URL | CC | payload | run)
- Labeled metric cards (REQUESTS/SUCCESS/ERRORS/LATENCY) with uppercase labels
- RPS integrated into metrics strip during runs
- ⬩ RUN / ◼ CANCEL icons with distinctive button styling
- Drawer-style inspector with method badge + URL header
- 1xx status handling ("{code} Info")
- Sparkline as visual centerpiece with "LATENCY SPARKLINE" label
- Full-width separator borders between sections
- Cursor changed to ▸ for selected items
- ▸ cursor in header list
- Truncation indicator "..." in inspector body

Bug fixes:
- B1: Auto-scroll selection now correctly advances (save len before append)
- B2: Width cap removed (was clamped to 140, now uses full terminal width)
- B3: Height accounting fixed (accounts for app padding + panel overhead)
- B4: Sparkline leading space artifact removed
- U5: Body truncation now shows "... (truncated)" indicator
- U7: Latency ring buffer increased from 40 to 200 for wider sparkline window
- U10: Zero-latency bars no longer show a filled bar (removed max(1,...))
- S1: 1xx status responses handled as "Info"
- S6: RPS shown in metrics strip
- S7: Durations >= 60s formatted as "Xm Ys"

Code quality:
- AllowedMethods() call cached in local variable (C1)
- displayElapsed simplified to single condition (C9)
- monoStyle removed (dead code)
- formatDuration handles seconds and minutes properly

New tests across 3 files (64 total, up from 10):
- model_test.go: 18 new tests (auto-scroll advances, WindowSizeMsg, tickMsg idle, resultMsg auto-scroll/no-scroll, cap enforcement, runFinishedMsg, ctrl+c/r/x, esc from body/inspector, Init, concurrency parse, formatDuration, headerMap, clamp)
- view_test.go: 25 tests for all rendering functions (View, header, command, metrics, payload, tabs, timeline, logs, inspector, sparkline, footer, resultStatus, rowCursor, truncate, displayElapsed)
- styles_test.go: 11 tests for all style constructors (methodColor, methodStyle, controlStyle, runButtonStyle, pillStyle, rowStyle, errorRowStyle, bodyStyle, inputStyle, statusColor)