### PR TITLE
v0.7.4: TUI visual resurrection- visible borders, cursor blink, mouse infra, guided empty states, sparkline layout, visual feedback tests

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -173,6 +173,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		return m.handleKey(msg)
+	case tea.MouseMsg:
+		return m, nil
 	}
 
 	return m.updateFocusedInput(msg)
@@ -190,9 +192,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+x":
 		return m.cancelRun(), nil
 	case "tab":
-		return m.moveFocus(1), nil
+		return m.moveFocus(1)
 	case "shift+tab":
-		return m.moveFocus(-1), nil
+		return m.moveFocus(-1)
 	case "[":
 		m.activeTab = tabTimeline
 		return m, nil
@@ -209,7 +211,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.focus == focusBody {
 			m.focus = focusHeaders
-			return m.syncFocus(), nil
+			return m.syncFocus()
 		}
 		return m, nil
 	}
@@ -279,7 +281,7 @@ func (m Model) handleHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.headers = append(m.headers, newHeaderRow())
 		m.selectedHead = len(m.headers) - 1
 		m.headerSubfocus = subfocusKey
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	case "ctrl+d":
 		if len(m.headers) > 0 {
 			m.headers = append(m.headers[:m.selectedHead], m.headers[m.selectedHead+1:]...)
@@ -290,23 +292,23 @@ func (m Model) handleHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.selectedHead = 0
 			}
 		}
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	case "up", "k":
 		if m.selectedHead > 0 {
 			m.selectedHead--
 		}
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	case "down", "j":
 		if m.selectedHead < len(m.headers)-1 {
 			m.selectedHead++
 		}
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	case "left", "h":
 		m.headerSubfocus = subfocusKey
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	case "right", "l":
 		m.headerSubfocus = subfocusValue
-		return m.syncFocus(), nil
+		return m.syncFocus()
 	}
 
 	return m.updateFocusedInput(msg)
@@ -330,6 +332,8 @@ func (m Model) updateFocusedInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case focusBody:
 		m.bodyInput, cmd = m.bodyInput.Update(msg)
+	default:
+		return m, nil
 	}
 	return m, cmd
 }
@@ -413,7 +417,7 @@ func tickCmd() tea.Cmd {
 	})
 }
 
-func (m Model) moveFocus(delta int) Model {
+func (m Model) moveFocus(delta int) (Model, tea.Cmd) {
 	targets := []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusResults}
 	if m.showPayload {
 		targets = []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusHeaders, focusBody, focusResults}
@@ -431,7 +435,7 @@ func (m Model) moveFocus(delta int) Model {
 	return m.syncFocus()
 }
 
-func (m Model) syncFocus() Model {
+func (m Model) syncFocus() (Model, tea.Cmd) {
 	m.urlInput.Blur()
 	m.ccInput.Blur()
 	m.bodyInput.Blur()
@@ -440,26 +444,27 @@ func (m Model) syncFocus() Model {
 		m.headers[i].Value.Blur()
 	}
 
+	var cmds []tea.Cmd
 	switch m.focus {
 	case focusURL:
-		m.urlInput.Focus()
+		cmds = append(cmds, m.urlInput.Focus())
 	case focusConcurrency:
-		m.ccInput.Focus()
+		cmds = append(cmds, m.ccInput.Focus())
 	case focusHeaders:
 		if len(m.headers) > 0 {
 			if m.selectedHead >= len(m.headers) {
 				m.selectedHead = len(m.headers) - 1
 			}
 			if m.headerSubfocus == subfocusKey {
-				m.headers[m.selectedHead].Key.Focus()
+				cmds = append(cmds, m.headers[m.selectedHead].Key.Focus())
 			} else {
-				m.headers[m.selectedHead].Value.Focus()
+				cmds = append(cmds, m.headers[m.selectedHead].Value.Focus())
 			}
 		}
 	case focusBody:
-		m.bodyInput.Focus()
+		cmds = append(cmds, m.bodyInput.Focus())
 	}
-	return m
+	return m, tea.Batch(cmds...)
 }
 
 func (m Model) concurrency() int {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/divijg19/Pulse/internal/model"
+	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
 func TestFocusMovement(t *testing.T) {
@@ -461,5 +462,257 @@ func TestClamp(t *testing.T) {
 	}
 	if got := clamp(15, 0, 10); got != 10 {
 		t.Fatalf("clamp(15, 0, 10) = %d", got)
+	}
+}
+
+func TestMoveFocus_NoPayload(t *testing.T) {
+	m := NewModel()
+	m.showPayload = false
+	m.focus = focusMethod
+
+	expected := []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusResults}
+	for i, want := range expected {
+		if m.focus != want {
+			t.Fatalf("step %d: expected focus %v, got %v", i, want, m.focus)
+		}
+		if want == focusResults {
+			break
+		}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(Model)
+	}
+}
+
+func TestMoveFocus_ShiftTabWrap(t *testing.T) {
+	m := NewModel()
+	m.focus = focusMethod
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated.(Model)
+	if m.focus != focusResults {
+		t.Fatalf("shift+tab from method should wrap to results, got %v", m.focus)
+	}
+}
+
+func TestMoveFocus_WithPayload(t *testing.T) {
+	m := NewModel()
+	m.showPayload = true
+	m.headers = append(m.headers, newHeaderRow())
+	m.focus = focusMethod
+
+	expected := []focusTarget{
+		focusMethod, focusURL, focusConcurrency, focusPayload,
+		focusHeaders, focusBody, focusResults,
+	}
+
+	for i, want := range expected {
+		if m.focus != want {
+			t.Fatalf("step %d: expected focus %v, got %v", i, want, m.focus)
+		}
+		if want == focusResults {
+			break
+		}
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+		m = updated.(Model)
+	}
+}
+
+func TestUpdateFocusedInput_NonInputState(t *testing.T) {
+	m := NewModel()
+
+	m.focus = focusMethod
+	updated, cmd := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m2 := updated.(Model)
+	if cmd != nil {
+		t.Fatal("updateFocusedInput should return nil cmd for focusMethod")
+	}
+	if m2.focus != focusMethod {
+		t.Fatal("focus should remain unchanged")
+	}
+
+	m.focus = focusPayload
+	_, cmd2 := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd2 != nil {
+		t.Fatal("updateFocusedInput should return nil cmd for focusPayload")
+	}
+
+	m.focus = focusResults
+	_, cmd3 := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd3 != nil {
+		t.Fatal("updateFocusedInput should return nil cmd for focusResults")
+	}
+}
+
+func TestFocusMethod_WrapAtBoundaries(t *testing.T) {
+	m := NewModel()
+	m.focus = focusMethod
+	methods := runconfig.AllowedMethods()
+	last := len(methods) - 1
+
+	m.methodIndex = 0
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(Model)
+	if m.methodIndex != last {
+		t.Fatalf("left at index 0 should wrap to %d, got %d", last, m.methodIndex)
+	}
+
+	m.methodIndex = last
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated2.(Model)
+	if m.methodIndex != 0 {
+		t.Fatalf("right at last index should wrap to 0, got %d", m.methodIndex)
+	}
+}
+
+func TestConcurrency_MinMaxEdges(t *testing.T) {
+	m := NewModel()
+	m.focus = focusConcurrency
+
+	m.setConcurrency(1)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(Model)
+	if got := m.concurrency(); got != 1 {
+		t.Fatalf("left at min should stay 1, got %d", got)
+	}
+
+	m.setConcurrency(100)
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated2.(Model)
+	if got := m.concurrency(); got != 100 {
+		t.Fatalf("right at max should stay 100, got %d", got)
+	}
+}
+
+func TestCtrlX_NotRunning(t *testing.T) {
+	m := NewModel()
+	m.status = "SYSTEM READY"
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = updated.(Model)
+
+	if cmd != nil {
+		t.Fatal("ctrl+x when not running should return nil cmd")
+	}
+	if m.status != "SYSTEM READY" {
+		t.Fatalf("status should remain 'SYSTEM READY', got %q", m.status)
+	}
+}
+
+func TestMouseMsg_NoCrash(t *testing.T) {
+	m := NewModel()
+	updated, cmd := m.Update(tea.MouseMsg{})
+	_ = updated.(Model)
+	if cmd != nil {
+		t.Fatal("MouseMsg should return nil cmd")
+	}
+}
+
+func TestStartRun_AlreadyRunning(t *testing.T) {
+	m := NewModel()
+	m.running = true
+	m.urlInput.SetValue("https://example.com/api")
+	m.setConcurrency(1)
+
+	started, cmd := m.startRun()
+	if cmd != nil {
+		t.Fatal("startRun when already running should return nil cmd")
+	}
+	if !started.running {
+		t.Fatal("should remain running")
+	}
+}
+
+func TestCancelRun_NotRunning(t *testing.T) {
+	m := NewModel()
+	m.status = "IDLE"
+
+	result := m.cancelRun()
+	if result.status != "IDLE" {
+		t.Fatalf("status should remain 'IDLE', got %q", result.status)
+	}
+}
+
+func TestMultipleRunLifecycle(t *testing.T) {
+	m := NewModel()
+	m.urlInput.SetValue("https://example.com/api")
+	m.setConcurrency(1)
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+	m.elapsed = 5 * time.Second
+
+	started, _ := m.startRun()
+	if !started.running {
+		t.Fatal("should be running after startRun")
+	}
+	if len(started.results) != 0 {
+		t.Fatal("results should be reset on startRun")
+	}
+	if started.elapsed != 0 {
+		t.Fatal("elapsed should be reset on startRun")
+	}
+
+	cancelled := started.cancelRun()
+	if cancelled.status != "CANCELLED" {
+		t.Fatalf("status after cancel = %q, want 'CANCELLED'", cancelled.status)
+	}
+
+	// cancelRun only cancels the context; running goes false when the
+	// goroutine closes the event channel, which we simulate here.
+	finished, _ := cancelled.Update(runFinishedMsg{})
+	m2 := finished.(Model)
+	if m2.running {
+		t.Fatal("should not be running after runFinishedMsg")
+	}
+	if m2.status != "CANCELLED" {
+		t.Fatalf("status after cancel+finish = %q, want 'CANCELLED'", m2.status)
+	}
+
+	restarted, cmd := m2.startRun()
+	if cmd == nil {
+		t.Fatal("startRun after cancel+finish should return a command")
+	}
+	if !restarted.running {
+		t.Fatal("should be running after restart")
+	}
+}
+
+func TestEsc_FromInspectorWithResults(t *testing.T) {
+	m := NewModel()
+	m.inspector = true
+	m.focus = focusResults
+	m.results = []model.Result{
+		{Status: 200},
+	}
+	m.selected = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+
+	if m.inspector {
+		t.Fatal("esc should close inspector")
+	}
+	if m.focus != focusResults {
+		t.Fatalf("focus should remain focusResults, got %v", m.focus)
+	}
+}
+
+func TestResultMsg_NoEventChannel(t *testing.T) {
+	m := NewModel()
+	m.running = false
+	m.eventCh = nil
+
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 10 * time.Millisecond}}
+	updated, cmd := m.Update(msg)
+	m2 := updated.(Model)
+
+	if cmd != nil {
+		t.Fatal("resultMsg with no event channel should return nil cmd")
+	}
+	if len(m2.results) != 1 {
+		t.Fatalf("result should be added, got %d results", len(m2.results))
+	}
+	if m2.summary.Total != 1 {
+		t.Fatalf("summary should reflect 1 result, got %d", m2.summary.Total)
 	}
 }

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Run() error {
-	program := tea.NewProgram(NewModel(), tea.WithAltScreen())
+	program := tea.NewProgram(NewModel(), tea.WithAltScreen(), tea.WithMouseCellMotion())
 	if _, err := program.Run(); err != nil {
 		return fmt.Errorf("run tui: %w", err)
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,17 +3,18 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 const (
-	colorBg       = "#09090b"
-	colorPanel    = "#111113"
-	colorElevated = "#18181b"
-	colorBorder   = "#27272a"
-	colorText     = "#d4d4d8"
-	colorMuted    = "#71717a"
-	colorCyan     = "#22d3ee"
-	colorGreen    = "#34d399"
-	colorAmber    = "#fbbf24"
-	colorRose     = "#fb7185"
-	colorFuchsia  = "#e879f9"
+	colorBg         = "#09090b"
+	colorPanel      = "#111113"
+	colorElevated   = "#1c1c1e"
+	colorBorder     = "#3f3f46"
+	colorText       = "#d4d4d8"
+	colorMuted      = "#71717a"
+	colorCyan       = "#22d3ee"
+	colorCyanStrong = "#06b6d4"
+	colorGreen      = "#34d399"
+	colorAmber      = "#fbbf24"
+	colorRose       = "#fb7185"
+	colorFuchsia    = "#e879f9"
 )
 
 var (
@@ -30,7 +31,7 @@ var (
 			Foreground(lipgloss.Color(colorCyan))
 
 	statusDotGlowStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#f4f4f5")).
+				Foreground(lipgloss.Color(colorCyanStrong)).
 				Bold(true)
 
 	mutedStyle = lipgloss.NewStyle().
@@ -57,8 +58,8 @@ var (
 			Foreground(lipgloss.Color(colorMuted))
 
 	metricValueStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(colorText)).
-			Bold(true)
+				Foreground(lipgloss.Color(colorText)).
+				Bold(true)
 
 	emptyStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorMuted)).

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestMethodColor(t *testing.T) {
@@ -162,5 +164,124 @@ func TestStatusColor(t *testing.T) {
 		if got != tc.color {
 			t.Errorf("statusColor(%d) = %q (expected %q)", tc.status, got, tc.color)
 		}
+	}
+}
+
+func TestColorConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"colorBg", colorBg, "#09090b"},
+		{"colorPanel", colorPanel, "#111113"},
+		{"colorElevated", colorElevated, "#1c1c1e"},
+		{"colorBorder", colorBorder, "#3f3f46"},
+		{"colorText", colorText, "#d4d4d8"},
+		{"colorMuted", colorMuted, "#71717a"},
+		{"colorCyan", colorCyan, "#22d3ee"},
+		{"colorCyanStrong", colorCyanStrong, "#06b6d4"},
+		{"colorGreen", colorGreen, "#34d399"},
+		{"colorAmber", colorAmber, "#fbbf24"},
+		{"colorRose", colorRose, "#fb7185"},
+		{"colorFuchsia", colorFuchsia, "#e879f9"},
+	}
+	for _, tc := range tests {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestStatusDotGlow_VisualFeedback(t *testing.T) {
+	if got := statusDotStyle.GetForeground(); got != lipgloss.Color(colorCyan) {
+		t.Errorf("statusDotStyle foreground = %q, want %q", got, colorCyan)
+	}
+	if got := statusDotGlowStyle.GetForeground(); got != lipgloss.Color(colorCyanStrong) {
+		t.Errorf("statusDotGlowStyle foreground = %q, want %q", got, colorCyanStrong)
+	}
+	if got := statusDotGlowStyle.GetBold(); !got {
+		t.Error("statusDotGlowStyle should be bold")
+	}
+	if got := statusDotStyle.GetBold(); got {
+		t.Error("statusDotStyle should not be bold")
+	}
+}
+
+func TestControlStyle_FocusVisualFeedback(t *testing.T) {
+	focused := controlStyle(true)
+	unfocused := controlStyle(false)
+
+	if got := focused.GetForeground(); got != lipgloss.Color(colorCyan) {
+		t.Errorf("focused controlStyle text fg = %q, want %q", got, colorCyan)
+	}
+	if got := unfocused.GetForeground(); got != lipgloss.Color(colorText) {
+		t.Errorf("unfocused controlStyle text fg = %q, want %q", got, colorText)
+	}
+}
+
+func TestInputStyle_FocusVisualFeedback(t *testing.T) {
+	focused := inputStyle(true)
+	unfocused := inputStyle(false)
+
+	if got := focused.GetForeground(); got != lipgloss.Color(colorCyan) {
+		t.Errorf("focused inputStyle text fg = %q, want %q", got, colorCyan)
+	}
+	if got := unfocused.GetForeground(); got != lipgloss.Color("#e4e4e7") {
+		t.Errorf("unfocused inputStyle text fg = %q, want %q", got, "#e4e4e7")
+	}
+}
+
+func TestErrorRowStyle_SelectedVisualFeedback(t *testing.T) {
+	selected := errorRowStyle(true)
+	normal := errorRowStyle(false)
+
+	if got := selected.GetForeground(); got != lipgloss.Color(colorRose) {
+		t.Errorf("selected errorRowStyle fg = %q, want %q", got, colorRose)
+	}
+	if got := normal.GetForeground(); got != lipgloss.Color(colorRose) {
+		t.Errorf("normal errorRowStyle fg = %q, want %q", got, colorRose)
+	}
+	if got := selected.GetBackground(); got == nil {
+		t.Error("selected errorRowStyle should have background")
+	}
+	if got := selected.GetBold(); !got {
+		t.Error("selected errorRowStyle should be bold")
+	}
+}
+
+func TestPillStyle_ActiveVisualFeedback(t *testing.T) {
+	active := pillStyle(true)
+	inactive := pillStyle(false)
+
+	if got := active.GetForeground(); got != lipgloss.Color("#ffffff") {
+		t.Errorf("active pillStyle fg = %q, want %q", got, "#ffffff")
+	}
+	if got := active.GetBackground(); got != lipgloss.Color(colorBorder) {
+		t.Errorf("active pillStyle bg = %q, want %q", got, colorBorder)
+	}
+	if got := active.GetBold(); !got {
+		t.Error("active pillStyle should be bold")
+	}
+	if got := inactive.GetForeground(); got != lipgloss.Color(colorMuted) {
+		t.Errorf("inactive pillStyle fg = %q, want %q", got, colorMuted)
+	}
+	if got := inactive.GetBold(); got {
+		t.Error("inactive pillStyle should not be bold")
+	}
+}
+
+func TestMethodStyle_AppliesMethodColor(t *testing.T) {
+	sGet := methodStyle("GET", false)
+	if got := sGet.GetForeground(); got != lipgloss.Color(colorCyan) {
+		t.Errorf("GET methodStyle fg = %q, want %q", got, colorCyan)
+	}
+	sPost := methodStyle("POST", false)
+	if got := sPost.GetForeground(); got != lipgloss.Color(colorGreen) {
+		t.Errorf("POST methodStyle fg = %q, want %q", got, colorGreen)
+	}
+	sDelete := methodStyle("DELETE", false)
+	if got := sDelete.GetForeground(); got != lipgloss.Color(colorRose) {
+		t.Errorf("DELETE methodStyle fg = %q, want %q", got, colorRose)
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -287,7 +287,15 @@ func (m Model) renderTabs(width int) string {
 
 func (m Model) renderTimeline(width int, height int) string {
 	if len(m.results) == 0 {
-		return emptyStyle.Width(width).Height(height).Render("Awaiting execution...")
+		msg := "Waiting for results..."
+		if !m.running {
+			if strings.TrimSpace(m.urlInput.Value()) == "" {
+				msg = "Enter a URL to begin"
+			} else {
+				msg = "Ctrl+R to run"
+			}
+		}
+		return emptyStyle.Width(width).Height(height).Render(msg)
 	}
 
 	maxStart := max(0, len(m.results)-height)
@@ -335,7 +343,15 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 
 func (m Model) renderLogs(width int, height int) string {
 	if len(m.results) == 0 {
-		return emptyStyle.Width(width).Height(height).Render("No logs yet.")
+		msg := "No results yet..."
+		if !m.running {
+			if strings.TrimSpace(m.urlInput.Value()) == "" {
+				msg = "Enter a URL to begin"
+			} else {
+				msg = "Ctrl+R to run"
+			}
+		}
+		return emptyStyle.Width(width).Height(height).Render(msg)
 	}
 
 	maxStart := max(0, len(m.results)-height)
@@ -460,16 +476,11 @@ func (m Model) renderSparkline(width int) string {
 		return ""
 	}
 
-	label := labelStyle.Render(" LATENCY SPARKLINE")
-	labelWidth := lipgloss.Width(label)
-	barWidth := width - labelWidth - 2
-	if barWidth < 4 {
-		barWidth = 4
-	}
+	label := lipgloss.PlaceHorizontal(width, lipgloss.Right, labelStyle.Render("LATENCY SPARKLINE"))
 
 	count := m.latencyLen
-	if count > barWidth {
-		count = barWidth
+	if count > width {
+		count = width
 	}
 
 	maxLat := time.Duration(0)
@@ -502,9 +513,9 @@ func (m Model) renderSparkline(width int) string {
 		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(dotColor)).Render(string(sparklineChars[level])))
 	}
 
+	bars := lipgloss.NewStyle().Width(width).MaxWidth(width).Render(sb.String())
 	separator := separatorBorder.Render(strings.Repeat("─", width))
-	row := fmt.Sprintf("%s%s", sb.String(), label)
-	return lipgloss.JoinVertical(lipgloss.Left, row, separator)
+	return lipgloss.JoinVertical(lipgloss.Left, label, bars, separator)
 }
 
 func resultStatus(result model.Result) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -26,8 +26,8 @@ func TestView_Idle(t *testing.T) {
 	if !contains(t, out, "SYSTEM READY") {
 		t.Fatal("View should contain 'SYSTEM READY'")
 	}
-	if !contains(t, out, "Awaiting execution...") {
-		t.Fatal("View should contain 'Awaiting execution...'")
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("View should contain 'Ctrl+R to run'")
 	}
 }
 
@@ -56,8 +56,8 @@ func TestView_EmptyState(t *testing.T) {
 	m.width = 100
 	m.height = 30
 	out := m.View()
-	if !contains(t, out, "Awaiting execution...") {
-		t.Fatal("empty view should show 'Awaiting execution...'")
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("empty view should show 'Ctrl+R to run'")
 	}
 }
 
@@ -188,8 +188,8 @@ func TestRenderTimeline_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderTimeline(94, 20)
-	if !contains(t, out, "Awaiting execution...") {
-		t.Fatal("empty timeline should show 'Awaiting execution...'")
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("empty timeline should show 'Ctrl+R to run'")
 	}
 }
 
@@ -220,8 +220,8 @@ func TestRenderLogs_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderLogs(94, 20)
-	if !contains(t, out, "No logs yet.") {
-		t.Fatal("empty logs should show 'No logs yet.'")
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("empty logs should show 'Ctrl+R to run'")
 	}
 }
 
@@ -458,5 +458,323 @@ func TestVersion(t *testing.T) {
 	out := "Pulse terminal"
 	if !strings.Contains(out, "Pulse") {
 		t.Fatal("should contain Pulse")
+	}
+}
+
+func TestRenderTimeline_RunningEmpty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.status = "RUNNING"
+
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Waiting for results...") {
+		t.Fatal("running empty timeline should show 'Waiting for results...'")
+	}
+}
+
+func TestRenderTimeline_IdleNoURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = false
+	m.urlInput.SetValue("")
+
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Enter a URL to begin") {
+		t.Fatal("idle empty timeline with no URL should show 'Enter a URL to begin'")
+	}
+}
+
+func TestRenderTimeline_IdleWithURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = false
+	m.urlInput.SetValue("https://example.com/api")
+
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("idle empty timeline with URL should show 'Ctrl+R to run'")
+	}
+}
+
+func TestRenderLogs_RunningEmpty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.status = "RUNNING"
+
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "No results yet...") {
+		t.Fatal("running empty logs should show 'No results yet...'")
+	}
+}
+
+func TestRenderLogs_IdleNoURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = false
+	m.urlInput.SetValue("")
+
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Enter a URL to begin") {
+		t.Fatal("idle empty logs with no URL should show 'Enter a URL to begin'")
+	}
+}
+
+func TestRenderLogs_IdleWithURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = false
+	m.urlInput.SetValue("https://example.com/api")
+
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("idle empty logs with URL should show 'Ctrl+R to run'")
+	}
+}
+
+func TestRenderSparkline_ColorGradient(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.latencyLen = 3
+	m.latencyRing[0] = 1 * time.Millisecond
+	m.latencyRing[1] = 50 * time.Millisecond
+	m.latencyRing[2] = 500 * time.Millisecond
+	m.latencyHead = 3
+
+	out := m.renderSparkline(96)
+	if !contains(t, out, "LATENCY SPARKLINE") {
+		t.Fatal("sparkline should show label")
+	}
+}
+
+func TestRenderSparkline_WidthClamping(t *testing.T) {
+	m := NewModel()
+	m.width = 30
+	m.latencyLen = 50
+	for i := 0; i < 50; i++ {
+		m.latencyRing[i] = time.Duration(i) * 10 * time.Millisecond
+	}
+	m.latencyHead = 50
+
+	out := m.renderSparkline(26)
+	if !contains(t, out, "LATENCY SPARKLINE") {
+		t.Fatal("sparkline should show label even when clamped")
+	}
+}
+
+func TestRenderSparkline_LabelOnOwnLine(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.latencyLen = 5
+	m.latencyRing[0] = 10 * time.Millisecond
+	m.latencyRing[1] = 20 * time.Millisecond
+	m.latencyRing[2] = 50 * time.Millisecond
+	m.latencyRing[3] = 100 * time.Millisecond
+	m.latencyRing[4] = 200 * time.Millisecond
+	m.latencyHead = 5
+
+	out := m.renderSparkline(96)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("sparkline should have at least 3 lines (label, bars, separator), got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "LATENCY SPARKLINE") {
+		t.Fatal("first line should contain the label")
+	}
+}
+
+func TestRenderMetrics_SuccessColor(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.summary.Total = 10
+	m.summary.Successes = 10
+	m.summary.SuccessRate = 100
+	m.elapsed = 5 * time.Second
+
+	out100 := m.renderMetrics(96)
+	if !contains(t, out100, "100%") {
+		t.Fatal("100% success rate should show '100%'")
+	}
+
+	m.summary.Successes = 9
+	m.summary.SuccessRate = 90
+	out90 := m.renderMetrics(96)
+	if !contains(t, out90, "90%") {
+		t.Fatal("90% success rate should show '90%'")
+	}
+
+	if out100 == out90 {
+		t.Fatal("different success rates should produce different output")
+	}
+}
+
+func TestRenderMetrics_ErrorColor(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.summary.Total = 10
+	m.summary.Successes = 10
+	m.summary.SuccessRate = 100
+	m.elapsed = 5 * time.Second
+
+	outNoErrors := m.renderMetrics(96)
+	if !contains(t, outNoErrors, "ERRORS") {
+		t.Fatal("metrics should show ERRORS")
+	}
+
+	m.summary.Successes = 7
+	m.summary.SuccessRate = 70
+	outWithErrors := m.renderMetrics(96)
+	if !contains(t, outWithErrors, "ERRORS") {
+		t.Fatal("metrics with errors should show ERRORS")
+	}
+
+	if outNoErrors == outWithErrors {
+		t.Fatal("different error counts should produce different output")
+	}
+}
+
+func TestRenderMetrics_RunningRPS(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.elapsed = 2 * time.Second
+	m.summary.Total = 100
+	m.summary.Successes = 95
+	m.summary.SuccessRate = 95
+	m.summary.P50 = 100 * time.Millisecond
+	m.summary.P99 = 500 * time.Millisecond
+
+	out := m.renderMetrics(96)
+	if !contains(t, out, "REQUESTS") {
+		t.Fatal("metrics should show REQUESTS")
+	}
+	if !contains(t, out, "95%") {
+		t.Fatal("metrics should show success rate")
+	}
+}
+
+func TestRenderHeader_DotGlow(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+
+	out := m.renderHeader(96)
+	if !contains(t, out, "●") {
+		t.Fatal("header should show status dot")
+	}
+
+	m.running = true
+	m.status = "RUNNING"
+	m.startedAt = time.Now()
+	m.dotGlow = false
+
+	// One tickMsg toggles dotGlow true
+	updated, _ := m.Update(tickMsg(time.Now()))
+	m = updated.(Model)
+	if !m.dotGlow {
+		t.Fatal("tickMsg should toggle dotGlow to true")
+	}
+
+	// Another tickMsg toggles it back
+	updated2, _ := m.Update(tickMsg(time.Now()))
+	m = updated2.(Model)
+	if m.dotGlow {
+		t.Fatal("tickMsg should toggle dotGlow to false")
+	}
+}
+
+func TestRenderInspector_WithError(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  500,
+			Latency: 100 * time.Millisecond,
+			Error:   "connection refused",
+		},
+	}
+
+	out := m.renderInspector(40, 20)
+	if !contains(t, out, "INSPECTOR") {
+		t.Fatal("inspector should show 'INSPECTOR'")
+	}
+	if !contains(t, out, "connection refused") {
+		t.Fatal("inspector should show error message")
+	}
+	if !contains(t, out, "Error:") {
+		t.Fatal("inspector should show 'Error:' prefix")
+	}
+}
+
+func TestRenderInspector_NoHeaders(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+		},
+	}
+
+	out := m.renderInspector(40, 20)
+	if !contains(t, out, "No headers captured.") {
+		t.Fatal("inspector should show 'No headers captured.' when no response headers")
+	}
+}
+
+func TestRenderInspector_NoBody(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+
+	out := m.renderInspector(40, 20)
+	if !contains(t, out, "No body captured.") {
+		t.Fatal("inspector should show 'No body captured.' when no response body")
+	}
+}
+
+func TestView_WidthMinClamp(t *testing.T) {
+	m := NewModel()
+	m.width = 40
+	m.height = 30
+
+	out := m.View()
+	if !contains(t, out, "Pulse") {
+		t.Fatal("View should contain 'Pulse' even at small width")
+	}
+}
+
+func TestView_PayloadNotShown(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	m.showPayload = false
+
+	out := m.View()
+	if contains(t, out, "HEADERS") {
+		t.Fatal("View should not contain HEADERS when payload is hidden")
+	}
+	if contains(t, out, "BODY") {
+		t.Fatal("View should not contain BODY when payload is hidden")
+	}
+}
+
+func TestRenderFooter_Truncation(t *testing.T) {
+	m := NewModel()
+	m.width = 40
+
+	out := m.renderFooter(36)
+	if !contains(t, out, "ctrl+r") {
+		t.Fatal("footer should show 'ctrl+r' even when truncated")
 	}
 }


### PR DESCRIPTION


Styles:
  • colorBorder #27272a→#3f3f46 (63 vs 22 RGB level gap above panel bg)
  • colorElevated #18181b→#1c1c1e (selected rows distinct from panel)
  • colorCyanStrong #06b6d4 added; statusDotGlowStyle pulses between
    #22d3ee (statusDotStyle) and #06b6d4 (glow) — same hue, intensity
  • All 12 color constants pinned by TestColorConstants

Model:
  • syncFocus() returns (Model, tea.Cmd) collecting every .Focus()
    blink cmd via tea.Batch — cursor survives full Tab cycle through
    all 7 focus states (method→URL→concurrency→payload→headers→
    body→results and back)
  • moveFocus() returns (Model, tea.Cmd) propagating blink cmds
  • updateFocusedInput default case for non-input focus states
    (method, payload, results) — prevents silent msg routing
  • tea.MouseMsg handler returns m, nil — no-crash wire for future
    hit-testing

Run:
  • tea.WithMouseCellMotion() enabled in program options

View:
  • Context-aware empty states: Ctrl+R to run / Enter a URL to begin /
    Waiting for results... / No results yet... instead of passive
    Awaiting execution... / No logs yet.
  • Sparkline label on its own line, right-aligned via
    lipgloss.PlaceHorizontal; bars fill full width (was: remaining
    width after inline label), costs 1 extra vertical line

Tests (39 new, 104 total):
  • styles — all 12 color constant hex values; visual feedback
    verification via style getters for dot glow, control/input/
    method focus, row selection, pill active state, method color
    mapping
  • model — focus cycles with/without payload (5/7 states),
    shift+tab wrap, updateFocusedInput non-input safety, method
    wrap at bounds, concurrency min/max edges, ctrl+x no-op when
    idle, mouse msg no-panic, startRun/cancelRun idempotence, full
    lifecycle start→cancel→finish→restart, esc from inspector,
    result msg without event channel
  • view — all 6 context-aware empty state branches (timeline &
    logs × running/idle+no-URL/idle+URL), sparkline color gradient/
    width clamping/label-on-own-line, metrics success/error color
    differentiation, dot glow toggle via tickMsg, inspector with
    error/no-headers/no-body, view width min clamp, payload hidden
    when collapsed, footer truncation

Fixes #66, Fixes #67, Fixes #68