### PR TITLE
v0.7.6: Mode/Dialog/View dispatch, focus elimination, render consolidation

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,31 +17,37 @@ import (
 	"github.com/divijg19/Pulse/internal/stream"
 )
 
-type focusTarget int
-
-const (
-	focusMethod focusTarget = iota
-	focusURL
-	focusConcurrency
-	focusPayload
-	focusHeaders
-	focusBody
-	focusResults
-)
-
 const (
 	subfocusKey      = 0
 	subfocusValue    = 1
+	bodyFocus        = -1
 	latencyRingSize  = 200
 	defaultBodyWidth = 48
 	maxTUIBodyBytes  = 1 << 20
 )
 
-type resultTab int
+type mode int
 
 const (
-	tabTimeline resultTab = iota
-	tabLogs
+	modeObserve mode = iota
+	modeInspect
+)
+
+type dialog int
+
+const (
+	dialogNone dialog = iota
+	dialogEndpoint
+	dialogConcurrency
+	dialogPayload
+	dialogConfirmQuit
+)
+
+type view int
+
+const (
+	viewTimeline view = iota
+	viewLogs
 )
 
 type headerRow struct {
@@ -53,33 +59,32 @@ type Model struct {
 	width  int
 	height int
 
-	focus       focusTarget
+	mode   mode
+	dialog dialog
+	view   view
+
 	methodIndex int
 	urlInput    textinput.Model
 	ccInput     textinput.Model
 	bodyInput   textarea.Model
 
-	showPayload    bool
 	headers        []headerRow
 	selectedHead   int
 	headerSubfocus int
 
-	activeTab  resultTab
-	results    []model.Result
-	selected   int
-	inspector  bool
-	autoScroll bool
+	results  []model.Result
+	selected int
 
-	running     bool
-	startedAt   time.Time
-	elapsed     time.Duration
-	cancel      context.CancelFunc
-	eventCh     <-chan model.Event
-	status      string
-	errMsg      string
-	confirmQuit bool
-	capped      bool
-	summary     metrics.Summary
+	running   bool
+	startedAt time.Time
+	elapsed   time.Duration
+	cancel    context.CancelFunc
+	eventCh   <-chan model.Event
+	status    string
+	errMsg    string
+	capped    bool
+	summary   metrics.Summary
+
 	latencyRing [latencyRingSize]time.Duration
 	latencyHead int
 	latencyLen  int
@@ -105,7 +110,6 @@ func NewModel() Model {
 	url.SetValue("https://httpbin.org/delay/1")
 	url.Prompt = ""
 	url.CharLimit = 2048
-	url.Focus()
 
 	cc := textinput.New()
 	cc.SetValue(strconv.Itoa(runconfig.DefaultConcurrency))
@@ -121,13 +125,13 @@ func NewModel() Model {
 	body.SetWidth(defaultBodyWidth)
 
 	return Model{
-		focus:       focusURL,
+		mode:        modeObserve,
+		dialog:      dialogNone,
+		view:        viewTimeline,
 		methodIndex: 0,
 		urlInput:    url,
 		ccInput:     cc,
 		bodyInput:   body,
-		activeTab:   tabTimeline,
-		autoScroll:  true,
 		status:      "SYSTEM READY",
 	}
 }
@@ -168,14 +172,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.latencyLen < latencyRingSize {
 			m.latencyLen++
 		}
-		before := len(m.results)
+		following := m.isFollowingTail()
 		if len(m.results) < 10000 {
 			m.results = append(m.results, msg.Result)
 		} else {
 			m.capped = true
 		}
 		m.summary = metrics.Compute(m.results, m.elapsed)
-		if m.autoScroll && m.selected >= before-1 {
+		if following {
 			m.selected = len(m.results) - 1
 		}
 		if m.running && m.eventCh != nil {
@@ -205,131 +209,131 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	return m.updateFocusedInput(msg)
+	return m, nil
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.errMsg = ""
 
-	if m.confirmQuit {
-		m.confirmQuit = false
-		if msg.String() == "ctrl+c" || msg.String() == "q" {
-			if m.running && m.cancel != nil {
-				m.cancel()
-			}
-			return m, tea.Quit
+	switch m.mode {
+	case modeObserve:
+		switch m.dialog {
+		case dialogEndpoint:
+			return m.handleEndpointKey(msg)
+		case dialogConcurrency:
+			return m.handleCCKey(msg)
+		case dialogPayload:
+			return m.handlePayloadKey(msg)
+		case dialogConfirmQuit:
+			return m.handleConfirmQuitKey(msg)
+		case dialogNone:
+			return m.handleObserveKey(msg)
 		}
-		return m, nil
+	case modeInspect:
+		switch m.dialog {
+		case dialogConfirmQuit:
+			return m.handleConfirmQuitKey(msg)
+		case dialogNone:
+			return m.handleInspectKey(msg)
+		}
 	}
+	return m, nil
+}
 
+func (m Model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.dialog = dialogNone
 	switch msg.String() {
-	case "ctrl+c", "q":
-		if m.running {
-			m.confirmQuit = true
-			return m, nil
+	case "ctrl+c", "q", "enter":
+		if m.running && m.cancel != nil {
+			m.cancel()
 		}
 		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleEndpointKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "enter":
+		m.dialog = dialogNone
+		m.urlInput.Blur()
+		return m, nil
 	case "ctrl+r":
 		return m.startRun()
 	case "ctrl+x":
 		return m.cancelRun(), nil
-	case "tab":
-		return m.moveFocus(1)
-	case "shift+tab":
-		return m.moveFocus(-1)
-	case "[":
-		m.activeTab = tabTimeline
-		return m, nil
-	case "]":
-		m.activeTab = tabLogs
-		return m, nil
-	case "ctrl+a":
-		m.autoScroll = !m.autoScroll
-		return m, nil
-	case "esc":
-		if m.inspector {
-			m.inspector = false
-			return m, nil
-		}
-		if m.focus == focusBody {
-			m.focus = focusHeaders
-			return m.syncFocus()
-		}
-		if m.focus == focusResults {
-			m.focus = focusURL
-			return m.syncFocus()
-		}
-		return m, nil
 	}
-
-	switch m.focus {
-	case focusMethod:
-		switch msg.String() {
-		case "left", "h", "up", "k":
-			m.methodIndex = (m.methodIndex + len(runconfig.AllowedMethods()) - 1) % len(runconfig.AllowedMethods())
-			return m, nil
-		case "right", "l", "down", "j", "enter":
-			m.methodIndex = (m.methodIndex + 1) % len(runconfig.AllowedMethods())
-			return m, nil
-		}
-	case focusConcurrency:
-		switch msg.String() {
-		case "left", "h", "down", "j":
-			m.setConcurrency(m.concurrency() - 1)
-			return m, nil
-		case "right", "l", "up", "k":
-			m.setConcurrency(m.concurrency() + 1)
-			return m, nil
-		}
-	case focusPayload:
-		if msg.String() == "enter" || msg.String() == " " {
-			m.showPayload = !m.showPayload
-			if m.showPayload && len(m.headers) == 0 {
-				m.headers = append(m.headers, newHeaderRow())
-			}
-			return m, nil
-		}
-	case focusHeaders:
-		return m.handleHeaderKey(msg)
-	case focusResults:
-		switch msg.String() {
-		case "up", "k":
-			if m.selected > 0 {
-				m.selected--
-			}
-			return m, nil
-		case "down", "j":
-			if m.selected < len(m.results)-1 {
-				m.selected++
-			}
-			return m, nil
-		case "pgup":
-			if len(m.results) > 0 {
-				pageSize := max(5, m.height/2)
-				m.selected = max(0, m.selected-pageSize)
-			}
-			return m, nil
-		case "pgdown":
-			if len(m.results) > 0 {
-				pageSize := max(5, m.height/2)
-				m.selected = min(len(m.results)-1, m.selected+pageSize)
-			}
-			return m, nil
-		case "enter":
-			if len(m.results) > 0 {
-				m.inspector = true
-			}
-			return m, nil
-		}
-	}
-
-	return m.updateFocusedInput(msg)
+	var cmd tea.Cmd
+	m.urlInput, cmd = m.urlInput.Update(msg)
+	return m, cmd
 }
 
-func (m Model) handleHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if !m.showPayload {
+func (m Model) handleCCKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "enter":
+		m.dialog = dialogNone
+		m.ccInput.Blur()
 		return m, nil
+	case "up", "k":
+		m.setConcurrency(m.concurrency() + 1)
+		return m, nil
+	case "down", "j":
+		m.setConcurrency(m.concurrency() - 1)
+		return m, nil
+	case "ctrl+r":
+		return m.startRun()
+	case "ctrl+x":
+		return m.cancelRun(), nil
 	}
+	var cmd tea.Cmd
+	m.ccInput, cmd = m.ccInput.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handlePayloadKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.dialog = dialogNone
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
+		}
+		return m, nil
+	case "ctrl+r":
+		return m.startRun()
+	case "ctrl+x":
+		return m.cancelRun(), nil
+	}
+
+	if m.selectedHead == bodyFocus {
+		switch msg.String() {
+		case "tab":
+			m.selectedHead = 0
+			if len(m.headers) == 0 {
+				m.headers = append(m.headers, newHeaderRow())
+			}
+			m.urlInput.Blur()
+			m.ccInput.Blur()
+			m.bodyInput.Blur()
+			for i := range m.headers {
+				m.headers[i].Key.Blur()
+				m.headers[i].Value.Blur()
+			}
+			if m.headerSubfocus == subfocusKey {
+				m.headers[m.selectedHead].Key.Focus()
+			} else {
+				m.headers[m.selectedHead].Value.Focus()
+			}
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.bodyInput, cmd = m.bodyInput.Update(msg)
+		return m, cmd
+	}
+
 	if len(m.headers) == 0 {
 		m.headers = append(m.headers, newHeaderRow())
 	}
@@ -339,7 +343,15 @@ func (m Model) handleHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.headers = append(m.headers, newHeaderRow())
 		m.selectedHead = len(m.headers) - 1
 		m.headerSubfocus = subfocusKey
-		return m.syncFocus()
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
+		}
+		m.headers[m.selectedHead].Key.Focus()
+		return m, nil
 	case "ctrl+d":
 		if len(m.headers) > 0 {
 			m.headers = append(m.headers[:m.selectedHead], m.headers[m.selectedHead+1:]...)
@@ -350,50 +362,158 @@ func (m Model) handleHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.selectedHead = 0
 			}
 		}
-		return m.syncFocus()
+		return m, nil
 	case "up", "k":
 		if m.selectedHead > 0 {
 			m.selectedHead--
 		}
-		return m.syncFocus()
+		return m, nil
 	case "down", "j":
 		if m.selectedHead < len(m.headers)-1 {
 			m.selectedHead++
 		}
-		return m.syncFocus()
+		return m, nil
 	case "left", "h":
 		m.headerSubfocus = subfocusKey
-		return m.syncFocus()
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
+		}
+		m.headers[m.selectedHead].Key.Focus()
+		return m, nil
 	case "right", "l":
 		m.headerSubfocus = subfocusValue
-		return m.syncFocus()
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
+		}
+		m.headers[m.selectedHead].Value.Focus()
+		return m, nil
+	case "tab":
+		m.selectedHead = bodyFocus
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
+		}
+		m.bodyInput.Focus()
+		return m, nil
+	default:
+		if m.selectedHead >= 0 && m.selectedHead < len(m.headers) {
+			var cmd tea.Cmd
+			if m.headerSubfocus == subfocusKey {
+				m.headers[m.selectedHead].Key, cmd = m.headers[m.selectedHead].Key.Update(msg)
+			} else {
+				m.headers[m.selectedHead].Value, cmd = m.headers[m.selectedHead].Value.Update(msg)
+			}
+			return m, cmd
+		}
 	}
 
-	return m.updateFocusedInput(msg)
+	return m, nil
 }
 
-func (m Model) updateFocusedInput(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-	switch m.focus {
-	case focusURL:
-		m.urlInput, cmd = m.urlInput.Update(msg)
-	case focusConcurrency:
-		m.ccInput, cmd = m.ccInput.Update(msg)
-	case focusHeaders:
+func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.selected > 0 {
+			m.selected--
+		}
+		return m, nil
+	case "down", "j":
+		if m.selected < len(m.results)-1 {
+			m.selected++
+		}
+		return m, nil
+	case "pgup":
+		if len(m.results) > 0 {
+			pageSize := max(5, m.height/2)
+			m.selected = max(0, m.selected-pageSize)
+		}
+		return m, nil
+	case "pgdown":
+		if len(m.results) > 0 {
+			pageSize := max(5, m.height/2)
+			m.selected = min(len(m.results)-1, m.selected+pageSize)
+		}
+		return m, nil
+	case "enter":
+		if len(m.results) > 0 {
+			m.mode = modeInspect
+		}
+		return m, nil
+	case "[":
+		m.view = viewTimeline
+		return m, nil
+	case "]":
+		m.view = viewLogs
+		return m, nil
+	case "e":
+		m.dialog = dialogEndpoint
+		m.urlInput.Focus()
+		return m, nil
+	case "c":
+		m.dialog = dialogConcurrency
+		m.ccInput.Focus()
+		return m, nil
+	case "p":
+		m.dialog = dialogPayload
+		m.selectedHead = 0
+		m.headerSubfocus = subfocusKey
 		if len(m.headers) == 0 {
-			break
+			m.headers = append(m.headers, newHeaderRow())
 		}
-		if m.headerSubfocus == 0 {
-			m.headers[m.selectedHead].Key, cmd = m.headers[m.selectedHead].Key.Update(msg)
-		} else {
-			m.headers[m.selectedHead].Value, cmd = m.headers[m.selectedHead].Value.Update(msg)
+		m.urlInput.Blur()
+		m.ccInput.Blur()
+		m.bodyInput.Blur()
+		for i := range m.headers {
+			m.headers[i].Key.Blur()
+			m.headers[i].Value.Blur()
 		}
-	case focusBody:
-		m.bodyInput, cmd = m.bodyInput.Update(msg)
-	default:
+		m.headers[m.selectedHead].Key.Focus()
+		return m, nil
+	case "ctrl+r":
+		return m.startRun()
+	case "ctrl+x":
+		return m.cancelRun(), nil
+	case "q", "ctrl+c":
+		if m.running {
+			m.dialog = dialogConfirmQuit
+			return m, nil
+		}
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleInspectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = modeObserve
+		return m, nil
+	case "up", "k":
+		if m.selected > 0 {
+			m.selected--
+		}
+		return m, nil
+	case "down", "j":
+		if m.selected < len(m.results)-1 {
+			m.selected++
+		}
+		return m, nil
+	case "q", "ctrl+c":
+		m.dialog = dialogConfirmQuit
 		return m, nil
 	}
-	return m, cmd
+	return m, nil
 }
 
 func (m Model) startRun() (Model, tea.Cmd) {
@@ -427,6 +547,8 @@ func (m Model) startRun() (Model, tea.Cmd) {
 	eventCh := make(chan model.Event, runconfig.MaxConcurrency)
 	hub.Add(eventCh)
 
+	m.mode = modeObserve
+	m.dialog = dialogNone
 	m.running = true
 	m.cancel = cancel
 	m.eventCh = eventCh
@@ -434,12 +556,9 @@ func (m Model) startRun() (Model, tea.Cmd) {
 	m.elapsed = 0
 	m.results = nil
 	m.selected = 0
-	m.inspector = false
-	m.confirmQuit = false
 	m.capped = false
 	m.errMsg = ""
 	m.status = "RUNNING"
-	m.autoScroll = true
 	m.summary = metrics.Summary{}
 	m.latencyHead = 0
 	m.latencyLen = 0
@@ -450,6 +569,10 @@ func (m Model) startRun() (Model, tea.Cmd) {
 	}()
 
 	return m, tea.Batch(waitForEvent(eventCh), tickCmd())
+}
+
+func (m Model) isFollowingTail() bool {
+	return len(m.results) == 0 || m.selected >= len(m.results)-1
 }
 
 func (m Model) cancelRun() Model {
@@ -485,56 +608,6 @@ func startupTimeout() tea.Cmd {
 	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
 		return startupMsg{}
 	})
-}
-
-func (m Model) moveFocus(delta int) (Model, tea.Cmd) {
-	targets := []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusResults}
-	if m.showPayload {
-		targets = []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusHeaders, focusBody, focusResults}
-	}
-
-	current := 0
-	for i, target := range targets {
-		if target == m.focus {
-			current = i
-			break
-		}
-	}
-	next := (current + delta + len(targets)) % len(targets)
-	m.focus = targets[next]
-	return m.syncFocus()
-}
-
-func (m Model) syncFocus() (Model, tea.Cmd) {
-	m.urlInput.Blur()
-	m.ccInput.Blur()
-	m.bodyInput.Blur()
-	for i := range m.headers {
-		m.headers[i].Key.Blur()
-		m.headers[i].Value.Blur()
-	}
-
-	var cmds []tea.Cmd
-	switch m.focus {
-	case focusURL:
-		cmds = append(cmds, m.urlInput.Focus())
-	case focusConcurrency:
-		cmds = append(cmds, m.ccInput.Focus())
-	case focusHeaders:
-		if len(m.headers) > 0 {
-			if m.selectedHead >= len(m.headers) {
-				m.selectedHead = len(m.headers) - 1
-			}
-			if m.headerSubfocus == subfocusKey {
-				cmds = append(cmds, m.headers[m.selectedHead].Key.Focus())
-			} else {
-				cmds = append(cmds, m.headers[m.selectedHead].Value.Focus())
-			}
-		}
-	case focusBody:
-		cmds = append(cmds, m.bodyInput.Focus())
-	}
-	return m, tea.Batch(cmds...)
 }
 
 func (m Model) concurrency() int {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,31 +9,18 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/divijg19/Pulse/internal/model"
-	"github.com/divijg19/Pulse/internal/runconfig"
 )
-
-func TestFocusMovement(t *testing.T) {
-	m := NewModel()
-	if m.focus != focusURL {
-		t.Fatalf("initial focus = %v", m.focus)
-	}
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(Model)
-	if m.focus != focusConcurrency {
-		t.Fatalf("focus after tab = %v", m.focus)
-	}
-}
 
 func TestMethodSelection(t *testing.T) {
 	m := NewModel()
-	m.focus = focusMethod
+	m.dialog = dialogEndpoint
+	m.urlInput.Focus()
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	// pressing Tab should not crash (Tab is a no-op in endpoint dialog currently)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-
-	if got := m.methodIndex; got != 1 {
-		t.Fatalf("method index = %d", got)
+	if m.dialog != dialogEndpoint {
+		t.Fatal("tab should not close endpoint dialog")
 	}
 }
 
@@ -51,16 +38,15 @@ func TestConcurrencyClamping(t *testing.T) {
 
 func TestPayloadEditorState(t *testing.T) {
 	m := NewModel()
-	m.focus = focusPayload
+	m.dialog = dialogPayload
+	m.selectedHead = 0
+	m.headerSubfocus = subfocusKey
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	m = updated.(Model)
-
-	if !m.showPayload {
-		t.Fatal("payload editor should be visible")
+	if m.dialog != dialogPayload {
+		t.Fatal("payload dialog should be active")
 	}
-	if len(m.headers) != 1 {
-		t.Fatalf("headers len = %d", len(m.headers))
+	if len(m.headers) != 0 {
+		t.Fatalf("headers len = %d (expect 0, lazily initialized)", len(m.headers))
 	}
 }
 
@@ -89,23 +75,24 @@ func TestRunStartAndCancelTransitions(t *testing.T) {
 	}
 }
 
-func TestTabSwitching(t *testing.T) {
+func TestViewSwitching(t *testing.T) {
 	m := NewModel()
+
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
 	m = updated.(Model)
-	if m.activeTab != tabLogs {
-		t.Fatalf("active tab = %v", m.activeTab)
+	if m.view != viewLogs {
+		t.Fatalf("view = %v (expected viewLogs)", m.view)
 	}
+
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'['}})
 	m = updated.(Model)
-	if m.activeTab != tabTimeline {
-		t.Fatalf("active tab = %v", m.activeTab)
+	if m.view != viewTimeline {
+		t.Fatalf("view = %v (expected viewTimeline)", m.view)
 	}
 }
 
 func TestResultSelection_PageUpDown(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
 	m.height = 30
 	for i := 0; i < 50; i++ {
 		m.results = append(m.results, model.Result{Status: 200})
@@ -127,46 +114,50 @@ func TestResultSelection_PageUpDown(t *testing.T) {
 	}
 }
 
-func TestResultSelectionAndInspector(t *testing.T) {
+func TestResultSelectionAndInspect(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
 	m.results = []model.Result{
 		{Status: http.StatusOK},
 		{Status: http.StatusInternalServerError},
 	}
 
+	// Navigate down to second result
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = updated.(Model)
 	if m.selected != 1 {
 		t.Fatalf("selected = %d", m.selected)
 	}
 
+	// Enter Inspect mode
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(Model)
-	if !m.inspector {
-		t.Fatal("inspector should be open")
+	if m.mode != modeInspect {
+		t.Fatal("should enter inspect mode")
 	}
 
+	// ESC back to Observe
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
-	if m.inspector {
-		t.Fatal("inspector should close on esc")
+	if m.mode != modeObserve {
+		t.Fatal("should return to observe mode")
 	}
 }
 
 func TestHeaderAddRemove(t *testing.T) {
 	m := NewModel()
-	m.showPayload = true
-	m.focus = focusHeaders
+	m.dialog = dialogPayload
+	m.selectedHead = 0
+	m.headerSubfocus = subfocusKey
+	m.headers = append(m.headers, newHeaderRow())
 
-	// handleHeaderKey auto-adds one header when the slice is empty,
-	// so after the first ctrl+n there will be 2.
+	// ctrl+n adds a header row
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
 	m = updated.(Model)
 	if len(m.headers) != 2 {
 		t.Fatalf("after ctrl+n headers = %d (expected 2)", len(m.headers))
 	}
 
+	// ctrl+d removes last header row
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
 	m = updated.(Model)
 	if len(m.headers) != 1 {
@@ -193,59 +184,57 @@ func TestRejectsOversizedBody(t *testing.T) {
 	}
 }
 
-func TestAutoScrollToggle(t *testing.T) {
+func TestIsFollowingTail_Empty(t *testing.T) {
 	m := NewModel()
-	if !m.autoScroll {
-		t.Fatal("autoScroll should default to true")
-	}
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
-	m = updated.(Model)
-	if m.autoScroll {
-		t.Fatal("autoScroll should toggle to false")
-	}
-
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
-	m = updated.(Model)
-	if !m.autoScroll {
-		t.Fatal("autoScroll should toggle back to true")
-	}
-
-	m.autoScroll = false
-	m.urlInput.SetValue("https://example.com/api")
-	m, _ = m.startRun()
-	if !m.autoScroll {
-		t.Fatal("autoScroll should reset to true on startRun")
+	if !m.isFollowingTail() {
+		t.Fatal("should follow tail when results are empty")
 	}
 }
 
-func TestAutoScrollSelectionAdvances(t *testing.T) {
+func TestIsFollowingTail_AtBottom(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
-	m.autoScroll = true
-	m.startRun()
+	m.results = []model.Result{
+		{Status: 200},
+		{Status: 200},
+		{Status: 200},
+	}
+	m.selected = 2
+	if !m.isFollowingTail() {
+		t.Fatal("should follow tail when selected is last result")
+	}
+}
 
-	msg := resultMsg{Result: model.Result{Status: 200, Latency: 10 * time.Millisecond}}
+func TestIsFollowingTail_ScrolledUp(t *testing.T) {
+	m := NewModel()
+	m.results = []model.Result{
+		{Status: 200},
+		{Status: 200},
+		{Status: 200},
+	}
+	m.selected = 0
+	if m.isFollowingTail() {
+		t.Fatal("should not follow tail when scrolled away from bottom")
+	}
+}
+
+func TestAutoScrollAdvancesSelection(t *testing.T) {
+	m := NewModel()
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+	m.selected = 0
+
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 20 * time.Millisecond}}
 	updated, _ := m.Update(msg)
 	m = updated.(Model)
 
-	if m.selected != 0 {
-		t.Fatalf("after first result, selected = %d (expected 0)", m.selected)
-	}
-
-	msg2 := resultMsg{Result: model.Result{Status: 200, Latency: 20 * time.Millisecond}}
-	updated2, _ := m.Update(msg2)
-	m = updated2.(Model)
-
 	if m.selected != 1 {
-		t.Fatalf("after second result with auto-scroll, selected = %d (expected 1)", m.selected)
+		t.Fatalf("after new result at bottom, selected = %d (expected 1)", m.selected)
 	}
 }
 
 func TestAutoScrollDoesNotAdvanceWhenScrolledAway(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
-	m.autoScroll = true
 	m.results = []model.Result{
 		{Status: 200},
 		{Status: 200},
@@ -285,30 +274,8 @@ func TestTickMsg_Idle(t *testing.T) {
 	}
 }
 
-func TestResultMsg_AutoScrollOffKeepsSelection(t *testing.T) {
-	m := NewModel()
-	m.focus = focusResults
-	m.autoScroll = false
-	m.results = []model.Result{
-		{Status: 200, Latency: 10 * time.Millisecond},
-		{Status: 200, Latency: 10 * time.Millisecond},
-	}
-	m.selected = 0
-
-	msg := resultMsg{Result: model.Result{Status: 200, Latency: 5 * time.Millisecond}}
-	updated, _ := m.Update(msg)
-	m = updated.(Model)
-
-	if m.selected != 0 {
-		t.Fatalf("selected should stay at 0 with auto-scroll off, got %d", m.selected)
-	}
-}
-
 func TestResultMsg_CapEnforced(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
-	m.autoScroll = false
-
 	capResults := 10000
 	for i := 0; i < capResults+5; i++ {
 		msg := resultMsg{Result: model.Result{Status: 200, Latency: 1 * time.Millisecond}}
@@ -338,20 +305,44 @@ func TestRunFinishedMsg(t *testing.T) {
 	}
 }
 
-func TestCtrlC_WhileRunning(t *testing.T) {
+func TestCtrlC_QuitIdle(t *testing.T) {
+	m := NewModel()
+	m.running = false
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	_ = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("ctrl+c while idle should return a quit command")
+	}
+}
+
+func TestQ_QuitIdle(t *testing.T) {
+	m := NewModel()
+	m.running = false
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_ = updated.(Model)
+
+	if cmd == nil {
+		t.Fatal("q while idle should return a quit command")
+	}
+}
+
+func TestCtrlC_WhileRunning_ShowsConfirm(t *testing.T) {
 	m := NewModel()
 	m.running = true
 	m.cancel = func() {}
 
-	// First ctrl+c shows confirmation, does not quit
+	// First ctrl+c shows confirmation dialog
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	m = updated.(Model)
 
 	if cmd != nil {
 		t.Fatal("first ctrl+c while running should return nil cmd (confirmation)")
 	}
-	if !m.confirmQuit {
-		t.Fatal("confirmQuit should be set after first ctrl+c")
+	if m.dialog != dialogConfirmQuit {
+		t.Fatal("dialog should be confirmQuit after first ctrl+c")
 	}
 
 	// Second ctrl+c confirms quit
@@ -363,15 +354,21 @@ func TestCtrlC_WhileRunning(t *testing.T) {
 	}
 }
 
-func TestCtrlC_Idle(t *testing.T) {
+func TestConfirmQuit_OtherKeyCancels(t *testing.T) {
 	m := NewModel()
-	m.running = false
+	m.running = true
+	m.dialog = dialogConfirmQuit
+	m.cancel = func() {}
 
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
-	_ = updated.(Model)
+	// Any key other than q/ctrl+c/enter cancels
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = updated.(Model)
 
-	if cmd == nil {
-		t.Fatal("ctrl+c while idle should return a quit command")
+	if cmd != nil {
+		t.Fatal("cancelling confirm should return nil cmd")
+	}
+	if m.dialog != dialogNone {
+		t.Fatal("dialog should be none after cancel")
 	}
 }
 
@@ -401,32 +398,6 @@ func TestCtrlX_Cancel(t *testing.T) {
 	}
 	if m.running {
 		t.Fatal("running should be false after cancelRun")
-	}
-}
-
-func TestEsc_FromBodyFocus(t *testing.T) {
-	m := NewModel()
-	m.showPayload = true
-	m.focus = focusBody
-	m.headers = append(m.headers, newHeaderRow())
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = updated.(Model)
-
-	if m.focus != focusHeaders {
-		t.Fatalf("focus = %v (expected focusHeaders)", m.focus)
-	}
-}
-
-func TestEsc_FromInspector(t *testing.T) {
-	m := NewModel()
-	m.inspector = true
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	m = updated.(Model)
-
-	if m.inspector {
-		t.Fatal("esc should close the inspector")
 	}
 }
 
@@ -516,124 +487,6 @@ func TestHeaderMap(t *testing.T) {
 	}
 	if hm["Content-Type"] != "application/json" {
 		t.Fatalf("Content-Type = %q", hm["Content-Type"])
-	}
-}
-
-func TestMoveFocus_NoPayload(t *testing.T) {
-	m := NewModel()
-	m.showPayload = false
-	m.focus = focusMethod
-
-	expected := []focusTarget{focusMethod, focusURL, focusConcurrency, focusPayload, focusResults}
-	for i, want := range expected {
-		if m.focus != want {
-			t.Fatalf("step %d: expected focus %v, got %v", i, want, m.focus)
-		}
-		if want == focusResults {
-			break
-		}
-		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = updated.(Model)
-	}
-}
-
-func TestMoveFocus_ShiftTabWrap(t *testing.T) {
-	m := NewModel()
-	m.focus = focusMethod
-
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
-	m = updated.(Model)
-	if m.focus != focusResults {
-		t.Fatalf("shift+tab from method should wrap to results, got %v", m.focus)
-	}
-}
-
-func TestMoveFocus_WithPayload(t *testing.T) {
-	m := NewModel()
-	m.showPayload = true
-	m.headers = append(m.headers, newHeaderRow())
-	m.focus = focusMethod
-
-	expected := []focusTarget{
-		focusMethod, focusURL, focusConcurrency, focusPayload,
-		focusHeaders, focusBody, focusResults,
-	}
-
-	for i, want := range expected {
-		if m.focus != want {
-			t.Fatalf("step %d: expected focus %v, got %v", i, want, m.focus)
-		}
-		if want == focusResults {
-			break
-		}
-		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
-		m = updated.(Model)
-	}
-}
-
-func TestUpdateFocusedInput_NonInputState(t *testing.T) {
-	m := NewModel()
-
-	m.focus = focusMethod
-	updated, cmd := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	m2 := updated.(Model)
-	if cmd != nil {
-		t.Fatal("updateFocusedInput should return nil cmd for focusMethod")
-	}
-	if m2.focus != focusMethod {
-		t.Fatal("focus should remain unchanged")
-	}
-
-	m.focus = focusPayload
-	_, cmd2 := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	if cmd2 != nil {
-		t.Fatal("updateFocusedInput should return nil cmd for focusPayload")
-	}
-
-	m.focus = focusResults
-	_, cmd3 := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	if cmd3 != nil {
-		t.Fatal("updateFocusedInput should return nil cmd for focusResults")
-	}
-}
-
-func TestFocusMethod_WrapAtBoundaries(t *testing.T) {
-	m := NewModel()
-	m.focus = focusMethod
-	methods := runconfig.AllowedMethods()
-	last := len(methods) - 1
-
-	m.methodIndex = 0
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	m = updated.(Model)
-	if m.methodIndex != last {
-		t.Fatalf("left at index 0 should wrap to %d, got %d", last, m.methodIndex)
-	}
-
-	m.methodIndex = last
-	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
-	m = updated2.(Model)
-	if m.methodIndex != 0 {
-		t.Fatalf("right at last index should wrap to 0, got %d", m.methodIndex)
-	}
-}
-
-func TestConcurrency_MinMaxEdges(t *testing.T) {
-	m := NewModel()
-	m.focus = focusConcurrency
-
-	m.setConcurrency(1)
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	m = updated.(Model)
-	if got := m.concurrency(); got != 1 {
-		t.Fatalf("left at min should stay 1, got %d", got)
-	}
-
-	m.setConcurrency(100)
-	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
-	m = updated2.(Model)
-	if got := m.concurrency(); got != 100 {
-		t.Fatalf("right at max should stay 100, got %d", got)
 	}
 }
 
@@ -734,67 +587,191 @@ func TestMultipleRunLifecycle(t *testing.T) {
 	}
 }
 
-func TestEsc_FromResultsNavigatesToURL(t *testing.T) {
+func TestObserve_EndpointDialogOpenClose(t *testing.T) {
 	m := NewModel()
-	m.focus = focusResults
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = updated.(Model)
+	if m.dialog != dialogEndpoint {
+		t.Fatal("pressing e should open endpoint dialog")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("pressing esc should close endpoint dialog")
+	}
+}
+
+func TestObserve_CCDialogOpenClose(t *testing.T) {
+	m := NewModel()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	m = updated.(Model)
+	if m.dialog != dialogConcurrency {
+		t.Fatal("pressing c should open concurrency dialog")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("pressing esc should close concurrency dialog")
+	}
+}
+
+func TestObserve_PayloadDialogOpenClose(t *testing.T) {
+	m := NewModel()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	m = updated.(Model)
+	if m.dialog != dialogPayload {
+		t.Fatal("pressing p should open payload dialog")
+	}
+	if len(m.headers) == 0 {
+		t.Fatal("opening payload dialog should initialize headers")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("pressing esc should close payload dialog")
+	}
+}
+
+func TestCCDialog_ArrowAdjustUp(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogConcurrency
+
+	initial := m.concurrency()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+
+	if m.concurrency() != initial+1 {
+		t.Fatalf("concurrency after up = %d (expected %d)", m.concurrency(), initial+1)
+	}
+}
+
+func TestCCDialog_ArrowAdjustDown(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogConcurrency
+	m.setConcurrency(50)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	if m.concurrency() != 49 {
+		t.Fatalf("concurrency after down = %d (expected 49)", m.concurrency())
+	}
+}
+
+func TestEndpointDialog_EnterCloses(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.urlInput.Focus()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("enter should close endpoint dialog")
+	}
+}
+
+func TestCCDialog_EnterCloses(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogConcurrency
+	m.ccInput.Focus()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("enter should close concurrency dialog")
+	}
+}
+
+func TestInspect_EnterFromObserve(t *testing.T) {
+	m := NewModel()
+	m.results = []model.Result{{Status: 200}}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if m.mode != modeInspect {
+		t.Fatal("enter with results should enter inspect mode")
+	}
+}
+
+func TestInspect_EscToObserve(t *testing.T) {
+	m := NewModel()
+	m.mode = modeInspect
 	m.results = []model.Result{{Status: 200}}
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
-	if m.focus != focusURL {
-		t.Fatalf("esc from results should go to URL, got %v", m.focus)
+	if m.mode != modeObserve {
+		t.Fatal("esc from inspect should return to observe")
 	}
 }
 
-func TestEsc_FromInspectorWithResults(t *testing.T) {
+func TestInspect_QuitOpensConfirm(t *testing.T) {
 	m := NewModel()
-	m.inspector = true
-	m.focus = focusResults
+	m.mode = modeInspect
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(Model)
+	if m.dialog != dialogConfirmQuit {
+		t.Fatal("q from inspect should open confirm dialog")
+	}
+}
+
+func TestViewSwitch_PreservesSelection(t *testing.T) {
+	m := NewModel()
 	m.results = []model.Result{
 		{Status: 200},
+		{Status: 200},
 	}
-	m.selected = 0
+	m.selected = 1
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
+	m2 := updated.(Model)
+	if m2.selected != 1 {
+		t.Fatalf("selection should be preserved after view switch, got %d", m2.selected)
+	}
+}
+
+func TestEndpointDialog_NotClosableByWrongKey(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.urlInput.Focus()
+
+	// Typing text should go to urlInput, not close dialog
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = updated.(Model)
+	if m.dialog != dialogEndpoint {
+		t.Fatal("typing text should not close endpoint dialog")
+	}
+	if !strings.Contains(m.urlInput.Value(), "/") {
+		t.Fatal("URL input should contain typed character")
+	}
+}
+
+func TestCCDialog_TypesDigits(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogConcurrency
+	m.ccInput.Focus()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 	m = updated.(Model)
 
-	if m.inspector {
-		t.Fatal("esc should close inspector")
-	}
-	if m.focus != focusResults {
-		t.Fatalf("focus should remain focusResults, got %v", m.focus)
+	if !strings.Contains(m.ccInput.Value(), "5") {
+		t.Fatal("CC input should contain typed digit")
 	}
 }
 
-func TestResultMsg_NoEventChannel(t *testing.T) {
+func TestPayloadDialog_HeaderNavigationUpDown(t *testing.T) {
 	m := NewModel()
-	m.running = false
-	m.eventCh = nil
-
-	msg := resultMsg{Result: model.Result{Status: 200, Latency: 10 * time.Millisecond}}
-	updated, cmd := m.Update(msg)
-	m2 := updated.(Model)
-
-	if cmd != nil {
-		t.Fatal("resultMsg with no event channel should return nil cmd")
-	}
-	if len(m2.results) != 1 {
-		t.Fatalf("result should be added, got %d results", len(m2.results))
-	}
-	if m2.summary.Total != 1 {
-		t.Fatalf("summary should reflect 1 result, got %d", m2.summary.Total)
-	}
-}
-
-func TestHeaderNavigation_UpDown(t *testing.T) {
-	m := NewModel()
-	m.showPayload = true
-	m.focus = focusHeaders
+	m.dialog = dialogPayload
+	m.selectedHead = 0
+	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow(), newHeaderRow())
-
-	if len(m.headers) != 2 {
-		t.Fatalf("expected 2 headers, got %d", len(m.headers))
-	}
 
 	m.selectedHead = 0
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
@@ -823,98 +800,101 @@ func TestHeaderNavigation_UpDown(t *testing.T) {
 	}
 }
 
-func TestHeaderNavigation_LeftRight(t *testing.T) {
+func TestPayloadDialog_TabToBody(t *testing.T) {
 	m := NewModel()
-	m.showPayload = true
-	m.focus = focusHeaders
+	m.dialog = dialogPayload
+	m.selectedHead = 0
+	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
-	m.headerSubfocus = subfocusValue
-	m, _ = m.syncFocus()
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
-	m2 := updated.(Model)
-	if m2.headerSubfocus != subfocusKey {
-		t.Fatalf("left should set headerSubfocus to subfocusKey, got %d", m2.headerSubfocus)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.selectedHead != bodyFocus {
+		t.Fatalf("tab from headers should go to body, got selectedHead=%d", m.selectedHead)
 	}
 
-	updated, _ = m2.Update(tea.KeyMsg{Type: tea.KeyRight})
-	m3 := updated.(Model)
-	if m3.headerSubfocus != subfocusValue {
-		t.Fatalf("right should set headerSubfocus to subfocusValue, got %d", m3.headerSubfocus)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.selectedHead != 0 {
+		t.Fatalf("tab from body should go to headers, got selectedHead=%d", m.selectedHead)
 	}
 }
 
-func TestHeaderNavigation_LeftRightAliases(t *testing.T) {
+func TestStartRun_ResetsDialogAndMode(t *testing.T) {
 	m := NewModel()
-	m.showPayload = true
-	m.focus = focusHeaders
-	m.headers = append(m.headers, newHeaderRow())
-	m.headerSubfocus = subfocusValue
-	m, _ = m.syncFocus()
+	m.mode = modeInspect
+	m.dialog = dialogEndpoint
+	m.urlInput.SetValue("https://example.com/api")
+	m.setConcurrency(1)
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
-	m2 := updated.(Model)
-	if m2.headerSubfocus != subfocusKey {
-		t.Fatalf("'h' should set headerSubfocus to subfocusKey, got %d", m2.headerSubfocus)
+	started, _ := m.startRun()
+	if started.mode != modeObserve {
+		t.Fatal("startRun should reset mode to Observe")
 	}
-
-	updated, _ = m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	m3 := updated.(Model)
-	if m3.headerSubfocus != subfocusValue {
-		t.Fatalf("'l' should set headerSubfocus to subfocusValue, got %d", m3.headerSubfocus)
+	if started.dialog != dialogNone {
+		t.Fatal("startRun should reset dialog to None")
 	}
 }
 
-func TestUpdateFocusedInput_Headers(t *testing.T) {
+func TestResultMsg_NoEventChannel(t *testing.T) {
 	m := NewModel()
-	m.showPayload = true
-	m.focus = focusHeaders
-	m.headers = append(m.headers, newHeaderRow())
-	m, _ = m.syncFocus()
+	m.running = false
+	m.eventCh = nil
 
-	updated, _ := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	msg := resultMsg{Result: model.Result{Status: 200, Latency: 10 * time.Millisecond}}
+	updated, cmd := m.Update(msg)
 	m2 := updated.(Model)
 
-	if m2.headers[0].Key.Value() != "a" {
-		t.Fatal("header key input should contain typed character")
+	if cmd != nil {
+		t.Fatal("resultMsg with no event channel should return nil cmd")
+	}
+	if len(m2.results) != 1 {
+		t.Fatalf("result should be added, got %d results", len(m2.results))
+	}
+	if m2.summary.Total != 1 {
+		t.Fatalf("summary should reflect 1 result, got %d", m2.summary.Total)
 	}
 }
 
-func TestUpdateFocusedInput_Body(t *testing.T) {
+func TestConfirmQuit_FromInspectMode(t *testing.T) {
 	m := NewModel()
-	m.focus = focusBody
-	m, _ = m.syncFocus()
+	m.mode = modeInspect
+	m.running = true
+	m.cancel = func() {}
 
-	updated, _ := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
-	m2 := updated.(Model)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = updated.(Model)
+	if m.dialog != dialogConfirmQuit {
+		t.Fatal("q from inspect should open confirm dialog")
+	}
 
-	if m2.bodyInput.Value() != "x" {
-		t.Fatal("body input should contain typed character")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	_ = updated.(Model)
+	if cmd == nil {
+		t.Fatal("confirm from inspect should return a quit command")
 	}
 }
 
-func TestUpdateFocusedInput_URL(t *testing.T) {
+func TestCCDialog_ClampAtMax(t *testing.T) {
 	m := NewModel()
-	m.focus = focusURL
-	m, _ = m.syncFocus()
+	m.dialog = dialogConcurrency
+	m.setConcurrency(100)
 
-	updated, _ := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
-	m2 := updated.(Model)
-
-	if !strings.Contains(m2.urlInput.Value(), "/") {
-		t.Fatal("URL input should contain typed character")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.concurrency() != 100 {
+		t.Fatalf("concurrency at max should stay 100, got %d", m.concurrency())
 	}
 }
 
-func TestUpdateFocusedInput_CC(t *testing.T) {
+func TestCCDialog_ClampAtMin(t *testing.T) {
 	m := NewModel()
-	m.focus = focusConcurrency
-	m, _ = m.syncFocus()
+	m.dialog = dialogConcurrency
+	m.setConcurrency(1)
 
-	updated, _ := m.updateFocusedInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
-	m2 := updated.(Model)
-
-	if !strings.Contains(m2.ccInput.Value(), "0") {
-		t.Fatal("CC input should contain typed character")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if m.concurrency() != 1 {
+		t.Fatalf("concurrency at min should stay 1, got %d", m.concurrency())
 	}
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,11 +14,11 @@ const (
 )
 
 var (
-	StyleBase      = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
-	StyleTopBar    = StyleBase.Copy().Bold(true)
-	StyleStatusBar = StyleBase.Copy().Background(lipgloss.Color(colorDark))
+	StyleBase       = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
+	StyleTopBar     = StyleBase.Copy().Bold(true)
+	StyleStatusBar  = StyleBase.Copy().Background(lipgloss.Color(colorDark))
 	StyleStatusMode = lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorBg)).Bold(true)
-	StyleSeparator = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	StyleSeparator  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 )
 
 func statusColor(status int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -18,9 +18,10 @@ func (m Model) View() string {
 
 	width := max(72, m.width)
 
+	payloadOpen := m.dialog == dialogPayload
 	fixed := 5
 	var payloadHeight int
-	if m.showPayload {
+	if payloadOpen {
 		payloadHeight = lipgloss.Height(m.renderPayload(width))
 		fixed += payloadHeight
 	}
@@ -42,38 +43,39 @@ func (m Model) View() string {
 	}
 	sb.WriteString(m.renderTabStrip(width))
 	sb.WriteString("\n")
-	if m.showPayload {
+	if payloadOpen {
 		sb.WriteString(m.renderPayload(width))
 		sb.WriteString("\n")
 	}
 
-	switch m.activeTab {
-	case tabTimeline:
-		if m.inspector && width >= 86 {
+	inspecting := m.mode == modeInspect
+	switch m.view {
+	case viewTimeline:
+		if inspecting && width >= 86 {
 			resultsWidth := width * 58 / 100
 			inspWidth := width - resultsWidth - 1
 			sb.WriteString(m.renderTimeline(resultsWidth, workspaceHeight))
 			sb.WriteString(" ")
-			sb.WriteString(m.renderInspector(inspWidth, workspaceHeight))
+			sb.WriteString(m.renderInspect(inspWidth, workspaceHeight))
 		} else {
 			sb.WriteString(m.renderTimeline(width, workspaceHeight))
-			if m.inspector {
+			if inspecting {
 				sb.WriteString("\n")
-				sb.WriteString(m.renderInspector(width, max(6, workspaceHeight/2)))
+				sb.WriteString(m.renderInspect(width, max(6, workspaceHeight/2)))
 			}
 		}
 	default:
-		if m.inspector && width >= 86 {
+		if inspecting && width >= 86 {
 			resultsWidth := width * 58 / 100
 			inspWidth := width - resultsWidth - 1
 			sb.WriteString(m.renderLogs(resultsWidth, workspaceHeight))
 			sb.WriteString(" ")
-			sb.WriteString(m.renderInspector(inspWidth, workspaceHeight))
+			sb.WriteString(m.renderInspect(inspWidth, workspaceHeight))
 		} else {
 			sb.WriteString(m.renderLogs(width, workspaceHeight))
-			if m.inspector {
+			if inspecting {
 				sb.WriteString("\n")
-				sb.WriteString(m.renderInspector(width, max(6, workspaceHeight/2)))
+				sb.WriteString(m.renderInspect(width, max(6, workspaceHeight/2)))
 			}
 		}
 	}
@@ -89,16 +91,13 @@ func (m Model) View() string {
 func (m Model) renderTopBar(width int) string {
 	method := runconfig.AllowedMethods()[m.methodIndex]
 	url := truncateURL(m.urlInput.Value(), 40)
-	if m.focus == focusURL {
-		url = "[" + url + "]"
-	}
 	left := method + " " + url
 
 	var state string
 	switch {
-	case m.confirmQuit:
+	case m.dialog == dialogConfirmQuit:
 		state = "● QUIT?"
-	case m.inspector:
+	case m.mode == modeInspect:
 		state = "● INSPECTING"
 	case m.running:
 		state = fmt.Sprintf("%d req    ● RUNNING %.1fs", len(m.results), m.elapsed.Seconds())
@@ -106,19 +105,13 @@ func (m Model) renderTopBar(width int) string {
 		state = fmt.Sprintf("%d req    ● COMPLETED %.1fs", len(m.results), m.elapsed.Seconds())
 	case m.status != "" && m.status != "SYSTEM READY":
 		cc := strings.TrimSpace(m.ccInput.Value())
-		if m.focus == focusConcurrency {
-			cc = "[" + cc + "]"
-		}
 		state = fmt.Sprintf("CC %s    %s", cc, m.renderTopBarStatus())
 	default:
 		cc := strings.TrimSpace(m.ccInput.Value())
-		if m.focus == focusConcurrency {
-			cc = "[" + cc + "]"
-		}
 		state = fmt.Sprintf("CC %s    ● IDLE", cc)
 	}
 
-	rightStyled := renderRightStyled(m.running, m.status, m.confirmQuit, state)
+	rightStyled := renderRightStyled(m.running, m.status, m.dialog == dialogConfirmQuit, state)
 
 	maxLeft := width - lipgloss.Width(rightStyled) - 3
 	if maxLeft < 16 {
@@ -167,7 +160,7 @@ func (m Model) renderMetrics(width int) string {
 
 func (m Model) renderTabStrip(width int) string {
 	var timeline, logs string
-	if m.activeTab == tabTimeline {
+	if m.view == viewTimeline {
 		timeline = StyleBase.Copy().Foreground(lipgloss.Color(colorAccent)).Render("▶ Timeline")
 		logs = StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render("  Logs")
 	} else {
@@ -182,7 +175,7 @@ func (m Model) renderPayload(width int) string {
 	var b strings.Builder
 
 	headersColor := colorMuted
-	if m.focus == focusHeaders {
+	if m.selectedHead != bodyFocus {
 		headersColor = colorAccent
 	}
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(headersColor)).Render("HEADERS  ctrl+n add  ctrl+d remove"))
@@ -207,7 +200,7 @@ func (m Model) renderPayload(width int) string {
 	b.WriteString("\n")
 
 	bodyColor := colorMuted
-	if m.focus == focusBody {
+	if m.selectedHead == bodyFocus {
 		bodyColor = colorAccent
 	}
 	bodyLen := len(m.bodyInput.Value())
@@ -231,24 +224,27 @@ func (m Model) renderStatusBar(width int) string {
 	var mode, hints string
 
 	switch {
-	case m.confirmQuit:
+	case m.dialog == dialogConfirmQuit:
 		mode = ""
 		hints = "PRESS Q AGAIN TO QUIT • any other key cancels"
-	case m.inspector:
+	case m.dialog == dialogEndpoint:
+		mode = "ENDPOINT"
+		hints = "• ESC back • Enter done"
+	case m.dialog == dialogConcurrency:
+		mode = "CONCURRENCY"
+		hints = "• ↑↓ adjust • ESC back"
+	case m.dialog == dialogPayload:
+		mode = "PAYLOAD"
+		hints = "• ESC back"
+	case m.mode == modeInspect:
 		mode = "INSPECTING"
 		hints = "• ↑↓ scroll • ESC back • Q quit"
 	case m.running:
 		mode = "RUNNING"
-		hints = "• TAB focus • ENTER inspect • ^X cancel • Q quit"
-	case m.focus == focusURL:
-		mode = "EDIT URL"
-		hints = "• TAB next • ESC cancel"
-	case m.focus == focusConcurrency:
-		mode = "EDIT CC"
-		hints = "• TAB next • ESC cancel"
+		hints = "• ↑↓ results • ENTER inspect • ^X cancel • Q quit"
 	default:
-		mode = "NORMAL"
-		hints = "• TAB focus • ENTER inspect • ^R run • ^X cancel • Q quit"
+		mode = "OBSERVE"
+		hints = "• ↑↓ results • ENTER inspect • [ ] views • e endpoint • c cc • p payload • ^R run • Q quit"
 	}
 
 	if mode == "" {
@@ -273,7 +269,7 @@ func (m Model) renderTimeline(width int, height int) string {
 	lines := make([]string, 0, min(len(m.results)-start, height))
 	for i := start; i < len(m.results) && len(lines) < height; i++ {
 		result := m.results[i]
-		sel := m.focus == focusResults && i == m.selected
+		sel := i == m.selected
 		lines = append(lines, m.renderTimelineRow(i, result, m.summary.MaxLatency, width, sel))
 	}
 	return strings.Join(lines, "\n")
@@ -322,7 +318,7 @@ func (m Model) renderLogs(width int, height int) string {
 	lines := make([]string, 0, min(len(m.results)-start, height))
 	for i := start; i < len(m.results) && len(lines) < height; i++ {
 		result := m.results[i]
-		sel := m.focus == focusResults && i == m.selected
+		sel := i == m.selected
 		status := resultStatus(result)
 		method := result.RequestMethod
 		if method == "" {
@@ -343,7 +339,7 @@ func (m Model) renderLogs(width int, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (m Model) renderInspector(width int, height int) string {
+func (m Model) renderInspect(width int, height int) string {
 	if len(m.results) == 0 || m.selected < 0 || m.selected >= len(m.results) {
 		return StyleBase.Copy().Width(width).Height(height).Render(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("No result selected."))
 	}

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -64,19 +64,6 @@ func TestRenderTopBar_Normal(t *testing.T) {
 	}
 }
 
-func TestRenderTopBar_EditURL(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.focus = focusURL
-	out := m.renderTopBar(100)
-	if !contains(t, out, "GET") {
-		t.Fatal("top bar should contain method")
-	}
-	if !contains(t, out, "httpbin") {
-		t.Fatal("top bar should contain URL value when URL is focused")
-	}
-}
-
 func TestRenderTopBar_Running(t *testing.T) {
 	m := NewModel()
 	m.width = 100
@@ -150,7 +137,7 @@ func TestRenderTopBar_IdleDefault(t *testing.T) {
 func TestRenderTopBar_Inspecting(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.inspector = true
+	m.mode = modeInspect
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
@@ -164,43 +151,10 @@ func TestRenderTopBar_Inspecting(t *testing.T) {
 func TestRenderTopBar_QuitConfirm(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.confirmQuit = true
+	m.dialog = dialogConfirmQuit
 	out := m.renderTopBar(100)
 	if !contains(t, out, "QUIT?") {
 		t.Fatal("top bar should show QUIT? confirmation")
-	}
-}
-
-func TestRenderTopBar_EditCC(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.focus = focusConcurrency
-	out := m.renderTopBar(100)
-	if !contains(t, out, "CC") {
-		t.Fatal("edit CC top bar should contain 'CC' label")
-	}
-	if !contains(t, out, "IDLE") {
-		t.Fatal("edit CC top bar should show IDLE state")
-	}
-}
-
-func TestRenderTopBar_URLFocus(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.focus = focusURL
-	out := m.renderTopBar(100)
-	if !contains(t, out, "[httpbin.org/delay/1]") {
-		t.Fatal("URL focus top bar should show bracketed URL")
-	}
-}
-
-func TestRenderTopBar_CCFocus(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.focus = focusConcurrency
-	out := m.renderTopBar(100)
-	if !contains(t, out, "[10]") {
-		t.Fatal("CC focus top bar should show bracketed concurrency")
 	}
 }
 
@@ -355,19 +309,6 @@ func TestRenderTabs(t *testing.T) {
 	}
 }
 
-func TestRenderTabs_NoManualIndicator(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.autoScroll = false
-	out := m.renderTabStrip(100)
-	if contains(t, out, "MANUAL") {
-		t.Fatal("tab strip should not show 'MANUAL' indicator")
-	}
-	if !contains(t, out, "Timeline") {
-		t.Fatal("tab strip should still show tabs when autoScroll is off")
-	}
-}
-
 func TestRenderTabs_ActiveMarker(t *testing.T) {
 	m := NewModel()
 	m.width = 100
@@ -379,7 +320,7 @@ func TestRenderTabs_ActiveMarker(t *testing.T) {
 		t.Fatal("tab strip should show inactive Logs tab without marker")
 	}
 
-	m.activeTab = tabLogs
+	m.view = viewLogs
 	out = m.renderTabStrip(100)
 	if !contains(t, out, "▶ Logs") {
 		t.Fatal("tab strip should show ▶ marker on active Logs tab")
@@ -392,13 +333,9 @@ func TestRenderTabs_ActiveMarker(t *testing.T) {
 func TestRenderStatusBar_Normal(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.focus = focusResults
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "NORMAL") {
-		t.Fatal("status bar should show 'NORMAL' mode")
-	}
-	if !contains(t, out, "TAB focus") {
-		t.Fatal("status bar should show tab hint")
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("status bar should show 'OBSERVE' mode")
 	}
 }
 
@@ -412,20 +349,30 @@ func TestRenderStatusBar_Running(t *testing.T) {
 	}
 }
 
-func TestRenderStatusBar_EditURL(t *testing.T) {
+func TestRenderStatusBar_EndpointDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.focus = focusURL
+	m.dialog = dialogEndpoint
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "EDIT URL") {
-		t.Fatal("status bar should show 'EDIT URL' mode")
+	if !contains(t, out, "ENDPOINT") {
+		t.Fatal("status bar should show 'ENDPOINT' mode")
+	}
+}
+
+func TestRenderStatusBar_CCDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogConcurrency
+	out := m.renderStatusBar(100)
+	if !contains(t, out, "CONCURRENCY") {
+		t.Fatal("status bar should show 'CONCURRENCY' mode")
 	}
 }
 
 func TestRenderStatusBar_Inspecting(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.inspector = true
+	m.mode = modeInspect
 	out := m.renderStatusBar(100)
 	if !contains(t, out, "INSPECTING") {
 		t.Fatal("status bar should show 'INSPECTING' mode")
@@ -435,7 +382,7 @@ func TestRenderStatusBar_Inspecting(t *testing.T) {
 func TestRenderStatusBar_QuitConfirm(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.confirmQuit = true
+	m.dialog = dialogConfirmQuit
 	out := m.renderStatusBar(100)
 	if !contains(t, out, "PRESS Q AGAIN TO QUIT") {
 		t.Fatal("status bar should show quit confirmation")
@@ -459,7 +406,6 @@ func TestRenderTimeline_Rows(t *testing.T) {
 		{Status: 404, Latency: 50 * time.Millisecond},
 	}
 	m.summary.MaxLatency = 100 * time.Millisecond
-	m.focus = focusResults
 	m.selected = 0
 
 	out := m.renderTimeline(94, 20)
@@ -492,7 +438,6 @@ func TestRenderLogs_Rows(t *testing.T) {
 		{Status: 500, Latency: 50 * time.Millisecond, RequestMethod: "POST", RequestURL: "https://example.com/error"},
 	}
 	m.summary.MaxLatency = 100 * time.Millisecond
-	m.focus = focusResults
 	m.selected = 0
 
 	out := m.renderLogs(94, 20)
@@ -513,16 +458,16 @@ func TestRenderLogs_Rows(t *testing.T) {
 	}
 }
 
-func TestRenderInspector_NoSelection(t *testing.T) {
+func TestRenderInspect_NoSelection(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderInspector(40, 20)
+	out := m.renderInspect(40, 20)
 	if !contains(t, out, "No result selected.") {
 		t.Fatal("inspector with no selection should show 'No result selected.'")
 	}
 }
 
-func TestRenderInspector_WithResult(t *testing.T) {
+func TestRenderInspect_WithResult(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.selected = 0
@@ -537,7 +482,7 @@ func TestRenderInspector_WithResult(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspector(40, 20)
+	out := m.renderInspect(40, 20)
 	if !contains(t, out, "INSPECTOR") {
 		t.Fatal("inspector should show 'INSPECTOR'")
 	}
@@ -706,7 +651,7 @@ func TestRenderLogs_IdleWithURL(t *testing.T) {
 	}
 }
 
-func TestRenderInspector_WithError(t *testing.T) {
+func TestRenderInspect_WithError(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.selected = 0
@@ -718,7 +663,7 @@ func TestRenderInspector_WithError(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspector(40, 20)
+	out := m.renderInspect(40, 20)
 	if !contains(t, out, "INSPECTOR") {
 		t.Fatal("inspector should show 'INSPECTOR'")
 	}
@@ -730,7 +675,7 @@ func TestRenderInspector_WithError(t *testing.T) {
 	}
 }
 
-func TestRenderInspector_NoHeaders(t *testing.T) {
+func TestRenderInspect_NoHeaders(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.selected = 0
@@ -741,13 +686,13 @@ func TestRenderInspector_NoHeaders(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspector(40, 20)
+	out := m.renderInspect(40, 20)
 	if !contains(t, out, "No headers captured.") {
 		t.Fatal("inspector should show 'No headers captured.' when no response headers")
 	}
 }
 
-func TestRenderInspector_NoBody(t *testing.T) {
+func TestRenderInspect_NoBody(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.selected = 0
@@ -761,7 +706,7 @@ func TestRenderInspector_NoBody(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspector(40, 20)
+	out := m.renderInspect(40, 20)
 	if !contains(t, out, "No body captured.") {
 		t.Fatal("inspector should show 'No body captured.' when no response body")
 	}
@@ -785,21 +730,21 @@ func TestView_PayloadNotShown(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.height = 30
-	m.showPayload = false
 
 	out := m.View()
 	if contains(t, out, "HEADERS") {
-		t.Fatal("View should not contain HEADERS when payload is hidden")
+		t.Fatal("View should not contain HEADERS when payload dialog is closed")
 	}
 	if contains(t, out, "BODY") {
-		t.Fatal("View should not contain BODY when payload is hidden")
+		t.Fatal("View should not contain BODY when payload dialog is closed")
 	}
 }
 
 func TestRenderPayload_Open(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.showPayload = true
+	m.dialog = dialogPayload
+	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
@@ -822,7 +767,8 @@ func TestRenderPayload_Open(t *testing.T) {
 func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.showPayload = true
+	m.dialog = dialogPayload
+	m.selectedHead = 0
 
 	out := m.renderPayload(96)
 	if !contains(t, out, "No headers configured.") {
@@ -833,8 +779,8 @@ func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.showPayload = true
-	m.focus = focusHeaders
+	m.dialog = dialogPayload
+	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
@@ -849,14 +795,13 @@ func TestRenderWorkspace_InspectorStacked(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.height = 30
-	m.inspector = true
+	m.mode = modeInspect
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond,
 			ResponseHeaders: map[string]string{"Content-Type": "application/json"},
 			ResponseBody:    `{"ok": true}`},
 	}
 	m.selected = 0
-	m.focus = focusResults
 
 	out := m.View()
 	if !contains(t, out, "INSPECTOR") {
@@ -903,7 +848,6 @@ func TestRenderTimeline_Rows_Selected(t *testing.T) {
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
 	m.summary.MaxLatency = 100 * time.Millisecond
-	m.focus = focusResults
 	m.selected = 0
 
 	row := m.renderTimelineRow(0, m.results[0], m.summary.MaxLatency, 94, true)


### PR DESCRIPTION
Replace the state-machine focus/subfocus system with a clean mode/dialog/view triple that models the TUI as:
- mode: observe | inspect
- dialog: none | endpoint | concurrency | payload | confirmQuit
- view: timeline | logs

Key dispatch is now a structured match on (mode, dialog) instead of a flat FSM over an enum. Removed all focus fields (focus, subfocus, endpointSubfocus) from Model and their associated syncFocus plumbing.

Rendering consolidated from state.go via renderFSM into a direct switch on mode/view in View(). Deleted state.go entirely.

Tests updated: ~700 lines removed, ~660 added. All 8 packages green, go vet clean, go fmt clean.

Fixes:
- TestViewSwitch_PreservesSelection now checks returned model (was checking original by value semantics — false positive)
- handleObserveKey ctrl+x: removed redundant intermediate var
- Added CC clamp-at-boundary and confirm-from-inspect tests