### PR TITLE
v0.7.7: Ready launch surface, workspace-owned identity, screen-rent separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Design principles:
 
 ## Features
 
-- Canonical terminal UI with command bar, payload editor, live metrics, timeline/log views, and response inspector.
+- Canonical terminal UI with Ready launch pad, payload editor, live metrics, timeline/log views, and response inspector.
 - Optional browser WebUI started with `pulse web`.
 - Concurrent HTTP execution with immediate result streaming.
 - Payload editor for request headers and raw body.

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -17,67 +17,29 @@ func (m Model) View() string {
 	}
 
 	width := max(72, m.width)
-
-	payloadOpen := m.dialog == dialogPayload
-	fixed := 5
-	var payloadHeight int
-	if payloadOpen {
-		payloadHeight = lipgloss.Height(m.renderPayload(width))
-		fixed += payloadHeight
-	}
-
-	metricsStr := m.renderMetrics(width)
-	if metricsStr != "" {
-		fixed++
-	}
-	workspaceHeight := max(1, m.height-fixed)
+	bodyHeight := max(1, m.height-5)
 
 	var sb strings.Builder
 	sb.WriteString(m.renderTopBar(width))
 	sb.WriteString("\n")
 	sb.WriteString(StyleSeparator.Render(strings.Repeat("─", width)))
 	sb.WriteString("\n")
-	if metricsStr != "" {
-		sb.WriteString(metricsStr)
-		sb.WriteString("\n")
-	}
-	sb.WriteString(m.renderTabStrip(width))
-	sb.WriteString("\n")
-	if payloadOpen {
-		sb.WriteString(m.renderPayload(width))
-		sb.WriteString("\n")
-	}
 
-	inspecting := m.mode == modeInspect
-	switch m.view {
-	case viewTimeline:
-		if inspecting && width >= 86 {
-			resultsWidth := width * 58 / 100
-			inspWidth := width - resultsWidth - 1
-			sb.WriteString(m.renderTimeline(resultsWidth, workspaceHeight))
-			sb.WriteString(" ")
-			sb.WriteString(m.renderInspect(inspWidth, workspaceHeight))
-		} else {
-			sb.WriteString(m.renderTimeline(width, workspaceHeight))
-			if inspecting {
-				sb.WriteString("\n")
-				sb.WriteString(m.renderInspect(width, max(6, workspaceHeight/2)))
-			}
-		}
+	switch {
+	case m.dialog == dialogPayload:
+		sb.WriteString(m.renderPayload(width))
+	case m.dialog == dialogEndpoint:
+		sb.WriteString(m.renderEndpoint(width))
+	case m.dialog == dialogConcurrency:
+		sb.WriteString(m.renderConcurrency(width))
+	case m.mode == modeInspect:
+		sb.WriteString(m.renderInspect(width, bodyHeight))
+	case !m.running && len(m.results) == 0:
+		sb.WriteString(m.renderReady(width, bodyHeight))
+	case m.view == viewTimeline:
+		sb.WriteString(m.renderTimeline(width, bodyHeight))
 	default:
-		if inspecting && width >= 86 {
-			resultsWidth := width * 58 / 100
-			inspWidth := width - resultsWidth - 1
-			sb.WriteString(m.renderLogs(resultsWidth, workspaceHeight))
-			sb.WriteString(" ")
-			sb.WriteString(m.renderInspect(inspWidth, workspaceHeight))
-		} else {
-			sb.WriteString(m.renderLogs(width, workspaceHeight))
-			if inspecting {
-				sb.WriteString("\n")
-				sb.WriteString(m.renderInspect(width, max(6, workspaceHeight/2)))
-			}
-		}
+		sb.WriteString(m.renderLogs(width, bodyHeight))
 	}
 
 	sb.WriteString("\n")
@@ -88,96 +50,111 @@ func (m Model) View() string {
 	return StyleBase.Width(width).Height(m.height).Render(sb.String())
 }
 
+func identityCell(label string, subdued bool) string {
+	if subdued {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(label)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true).Render(label)
+}
+
+func (m Model) metricsString() string {
+	if !m.running && len(m.results) == 0 {
+		return ""
+	}
+	s := m.summary
+	rps := 0.0
+	if m.elapsed > 0 {
+		rps = float64(s.Total) / m.elapsed.Seconds()
+	}
+	return fmt.Sprintf("%d%% ok • %.1f r/s • p90 %s • p99 %s",
+		s.SuccessRate, rps, formatDuration(s.P90), formatDuration(s.P99))
+}
+
 func (m Model) renderTopBar(width int) string {
 	method := runconfig.AllowedMethods()[m.methodIndex]
 	url := truncateURL(m.urlInput.Value(), 40)
 	left := method + " " + url
 
-	var state string
-	switch {
-	case m.dialog == dialogConfirmQuit:
-		state = "● QUIT?"
-	case m.mode == modeInspect:
-		state = "● INSPECTING"
-	case m.running:
-		state = fmt.Sprintf("%d req    ● RUNNING %.1fs", len(m.results), m.elapsed.Seconds())
-	case m.status == "COMPLETE":
-		state = fmt.Sprintf("%d req    ● COMPLETED %.1fs", len(m.results), m.elapsed.Seconds())
-	case m.status != "" && m.status != "SYSTEM READY":
-		cc := strings.TrimSpace(m.ccInput.Value())
-		state = fmt.Sprintf("CC %s    %s", cc, m.renderTopBarStatus())
-	default:
-		cc := strings.TrimSpace(m.ccInput.Value())
-		state = fmt.Sprintf("CC %s    ● IDLE", cc)
-	}
+	cc := strings.TrimSpace(m.ccInput.Value())
+	right := "CC " + cc
 
-	rightStyled := renderRightStyled(m.running, m.status, m.dialog == dialogConfirmQuit, state)
-
-	maxLeft := width - lipgloss.Width(rightStyled) - 3
-	if maxLeft < 16 {
-		maxLeft = 16
+	maxLeft := width - lipgloss.Width(right) - 3
+	if maxLeft < 12 {
+		maxLeft = 12
 	}
 	leftTruncated := truncate(left, maxLeft)
-	padding := width - lipgloss.Width(leftTruncated) - lipgloss.Width(rightStyled)
+	padding := width - lipgloss.Width(leftTruncated) - lipgloss.Width(right)
 	if padding < 1 {
 		padding = 1
 	}
 
-	line := leftTruncated + strings.Repeat(" ", padding) + rightStyled
+	line := leftTruncated + strings.Repeat(" ", padding) + right
 	return StyleTopBar.Width(width).Render(line)
 }
 
-func (m Model) renderTopBarStatus() string {
-	return "● " + m.status
+func (m Model) renderReady(width int, height int) string {
+	method := runconfig.AllowedMethods()[m.methodIndex]
+	url := m.urlInput.Value()
+	cc := m.concurrency()
+
+	content := fmt.Sprintf("Press Ctrl+R to run\n\n%s %s\n\nCC %d\n\ne Endpoint    c Concurrency    p Payload",
+		method, url, cc)
+
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center,
+		lipgloss.NewStyle().Foreground(lipgloss.Color(colorText)).Render(content))
 }
 
-func renderRightStyled(running bool, status string, confirmQuit bool, right string) string {
-	if running || confirmQuit || status != "" && status != "SYSTEM READY" {
-		return StyleBase.Copy().Foreground(lipgloss.Color(colorAccent)).Render(right)
+func (m Model) renderEndpoint(width int) string {
+	var b strings.Builder
+	b.WriteString(identityCell("Endpoint", true))
+	b.WriteString("\n")
+
+	methods := runconfig.AllowedMethods()
+	var methodLine string
+	for i, method := range methods {
+		if i == m.methodIndex {
+			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("▶ " + method)
+		} else {
+			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("  " + method)
+		}
+		if i < len(methods)-1 {
+			methodLine += " "
+		}
 	}
-	return StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render(right)
+
+	b.WriteString(fmt.Sprintf(
+		"\n%s\n  %s\n%s\n  %s",
+		lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("URL"),
+		m.urlInput.Value(),
+		lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("Method"),
+		methodLine,
+	))
+
+	return b.String()
 }
 
-func (m Model) renderMetrics(width int) string {
-	if !m.running && len(m.results) == 0 {
-		return ""
-	}
-	s := m.summary
-	sep := StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render(" • ")
+func (m Model) renderConcurrency(width int) string {
+	var b strings.Builder
+	b.WriteString(identityCell("Concurrency", true))
+	b.WriteString("\n\n")
 
-	rps := 0.0
-	if m.elapsed > 0 {
-		rps = float64(s.Total) / m.elapsed.Seconds()
-	}
-
-	okStr := fmt.Sprintf("%d%% ok", s.SuccessRate)
-	rpsStr := fmt.Sprintf("%.1f r/s", rps)
-	p90Str := fmt.Sprintf("p90 %s", formatDuration(s.P90))
-	p99Str := fmt.Sprintf("p99 %s", formatDuration(s.P99))
-
-	return StyleBase.Copy().Width(width).Render(okStr + sep + rpsStr + sep + p90Str + sep + p99Str)
-}
-
-func (m Model) renderTabStrip(width int) string {
-	var timeline, logs string
-	if m.view == viewTimeline {
-		timeline = StyleBase.Copy().Foreground(lipgloss.Color(colorAccent)).Render("▶ Timeline")
-		logs = StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render("  Logs")
-	} else {
-		timeline = StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render("  Timeline")
-		logs = StyleBase.Copy().Foreground(lipgloss.Color(colorAccent)).Render("▶ Logs")
-	}
-	sep := StyleBase.Copy().Foreground(lipgloss.Color(colorMuted)).Render(" • ")
-	return StyleBase.Copy().Width(width).Render(timeline + " " + sep + " " + logs)
+	val := m.concurrency()
+	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true).Render(
+		fmt.Sprintf("  %d (1–%d)", val, runconfig.MaxConcurrency),
+	))
+	return b.String()
 }
 
 func (m Model) renderPayload(width int) string {
 	var b strings.Builder
+	b.WriteString(identityCell("Payload", true))
+	b.WriteString("\n")
 
 	headersColor := colorMuted
 	if m.selectedHead != bodyFocus {
 		headersColor = colorAccent
 	}
+	b.WriteString("\n")
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(headersColor)).Render("HEADERS  ctrl+n add  ctrl+d remove"))
 	b.WriteString("\n")
 
@@ -226,25 +203,25 @@ func (m Model) renderStatusBar(width int) string {
 	switch {
 	case m.dialog == dialogConfirmQuit:
 		mode = ""
-		hints = "PRESS Q AGAIN TO QUIT • any other key cancels"
+		hints = "q/Ctrl+C again to quit, any key cancels"
 	case m.dialog == dialogEndpoint:
 		mode = "ENDPOINT"
-		hints = "• ESC back • Enter done"
+		hints = "• ESC • ↵"
 	case m.dialog == dialogConcurrency:
 		mode = "CONCURRENCY"
-		hints = "• ↑↓ adjust • ESC back"
+		hints = "• ↑↓ • ESC"
 	case m.dialog == dialogPayload:
 		mode = "PAYLOAD"
-		hints = "• ESC back"
+		hints = "• ESC"
 	case m.mode == modeInspect:
 		mode = "INSPECTING"
-		hints = "• ↑↓ scroll • ESC back • Q quit"
+		hints = "• ↑↓ • ESC • Q"
 	case m.running:
 		mode = "RUNNING"
-		hints = "• ↑↓ results • ENTER inspect • ^X cancel • Q quit"
+		hints = "• ↑↓ • ENTER • ^X • Q"
 	default:
 		mode = "OBSERVE"
-		hints = "• ↑↓ results • ENTER inspect • [ ] views • e endpoint • c cc • p payload • ^R run • Q quit"
+		hints = "• ↑↓ • ENTER • [ ] views • e • c • p • ^R • Q"
 	}
 
 	if mode == "" {
@@ -257,22 +234,54 @@ func (m Model) renderStatusBar(width int) string {
 	return StyleStatusBar.Width(width).Render(line)
 }
 
+func visibleWindow(total, selected, height int) int {
+	if total <= height {
+		return 0
+	}
+	maxStart := total - height
+	start := selected - height/2
+	if start < 0 {
+		start = 0
+	}
+	if start > maxStart {
+		start = maxStart
+	}
+	return start
+}
+
 func (m Model) renderTimeline(width int, height int) string {
+	var b strings.Builder
+
+	b.WriteString(identityCell("Timeline", false))
+	b.WriteString("\n")
+
+	remaining := height - 1
+	if metrics := m.metricsString(); metrics != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Render(metrics))
+		b.WriteString("\n")
+		remaining--
+	}
+
+	if remaining <= 0 {
+		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+	}
+
 	if len(m.results) == 0 {
 		msg := m.renderEmptyState("⏳  Waiting for results...")
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Height(height).Render(msg)
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(msg))
+		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
 	}
 
-	maxStart := max(0, len(m.results)-height)
-	start := max(0, min(m.selected-height/2, maxStart))
-
-	lines := make([]string, 0, min(len(m.results)-start, height))
-	for i := start; i < len(m.results) && len(lines) < height; i++ {
+	start := visibleWindow(len(m.results), m.selected, remaining)
+	rows := make([]string, 0, min(len(m.results)-start, remaining))
+	for i := start; i < len(m.results) && len(rows) < remaining; i++ {
 		result := m.results[i]
 		sel := i == m.selected
-		lines = append(lines, m.renderTimelineRow(i, result, m.summary.MaxLatency, width, sel))
+		rows = append(rows, m.renderTimelineRow(i, result, m.summary.MaxLatency, width, sel))
 	}
-	return strings.Join(lines, "\n")
+	b.WriteString(strings.Join(rows, "\n"))
+
+	return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
 }
 
 func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time.Duration, width int, selected bool) string {
@@ -307,16 +316,31 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 }
 
 func (m Model) renderLogs(width int, height int) string {
-	if len(m.results) == 0 {
-		msg := m.renderEmptyState("📭  No results yet...")
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Height(height).Render(msg)
+	var b strings.Builder
+
+	b.WriteString(identityCell("Logs", false))
+	b.WriteString("\n")
+
+	remaining := height - 1
+	if metrics := m.metricsString(); metrics != "" {
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Render(metrics))
+		b.WriteString("\n")
+		remaining--
 	}
 
-	maxStart := max(0, len(m.results)-height)
-	start := max(0, min(m.selected-height/2, maxStart))
+	if remaining <= 0 {
+		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+	}
 
-	lines := make([]string, 0, min(len(m.results)-start, height))
-	for i := start; i < len(m.results) && len(lines) < height; i++ {
+	if len(m.results) == 0 {
+		msg := m.renderEmptyState("📭  No results yet...")
+		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(msg))
+		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+	}
+
+	start := visibleWindow(len(m.results), m.selected, remaining)
+	rows := make([]string, 0, min(len(m.results)-start, remaining))
+	for i := start; i < len(m.results) && len(rows) < remaining; i++ {
 		result := m.results[i]
 		sel := i == m.selected
 		status := resultStatus(result)
@@ -331,12 +355,14 @@ func (m Model) renderLogs(width int, height int) string {
 		line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
 			rowCursor(sel), i+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
 		if result.Status >= 400 || result.Status == 0 {
-			lines = append(lines, strings.TrimSpace(errorRowStyle(sel).Render(truncate(line, width))))
+			rows = append(rows, strings.TrimSpace(errorRowStyle(sel).Render(truncate(line, width))))
 		} else {
-			lines = append(lines, strings.TrimSpace(rowStyle(sel).Render(truncate(line, width))))
+			rows = append(rows, strings.TrimSpace(rowStyle(sel).Render(truncate(line, width))))
 		}
 	}
-	return strings.Join(lines, "\n")
+	b.WriteString(strings.Join(rows, "\n"))
+
+	return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
 }
 
 func (m Model) renderInspect(width int, height int) string {
@@ -358,8 +384,11 @@ func (m Model) renderInspect(width int, height int) string {
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	errorText := lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
 
+	identity := identityCell(fmt.Sprintf("Inspector — Result #%d", m.selected+1), false)
+
 	lines := []string{
-		sectionHeader.Render("INSPECTOR"),
+		identity,
+		"",
 		fmt.Sprintf("  %s %s", method, truncate(reqURL, width-12)),
 		"",
 		lipgloss.NewStyle().Foreground(lipgloss.Color(statusColor(result.Status))).Render("Status:  " + resultStatus(result)),

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -21,11 +21,8 @@ func TestView_Idle(t *testing.T) {
 	if !contains(t, out, "GET") {
 		t.Fatal("View should contain method")
 	}
-	if !contains(t, out, "IDLE") {
-		t.Fatal("View should contain 'IDLE'")
-	}
-	if !contains(t, out, "▶  Ctrl+R to run") {
-		t.Fatal("View should contain '▶  Ctrl+R to run'")
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("View should contain 'Ctrl+R to run' in Ready surface")
 	}
 }
 
@@ -47,9 +44,54 @@ func TestView_Running(t *testing.T) {
 	if !contains(t, out, "r/s") {
 		t.Fatal("running view should show requests per second")
 	}
+	if !contains(t, out, "Timeline") {
+		t.Fatal("running view should show Timeline identity")
+	}
 }
 
-func TestRenderTopBar_Normal(t *testing.T) {
+func TestRenderReady(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	out := m.renderReady(100, 26)
+	if !contains(t, out, "httpbin") {
+		t.Fatal("Ready should show URL")
+	}
+	if !contains(t, out, "CC 10") {
+		t.Fatal("Ready should show concurrency")
+	}
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("Ready should show run CTA")
+	}
+	if !contains(t, out, "Endpoint") {
+		t.Fatal("Ready should show endpoint action link")
+	}
+	if !contains(t, out, "Concurrency") {
+		t.Fatal("Ready should show concurrency action link")
+	}
+	if !contains(t, out, "Payload") {
+		t.Fatal("Ready should show payload action link")
+	}
+}
+
+func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+
+	out := m.View()
+	if !contains(t, out, "Ctrl+R to run") {
+		t.Fatal("first launch should show Ready surface")
+	}
+
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	out = m.View()
+	if contains(t, out, "Ready") {
+		t.Fatal("after results exist, Ready should not appear")
+	}
+}
+
+func TestRenderTopBar_ShowsMethodAndURL(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderTopBar(100)
@@ -59,102 +101,14 @@ func TestRenderTopBar_Normal(t *testing.T) {
 	if !contains(t, out, "httpbin") {
 		t.Fatal("top bar should contain URL")
 	}
-	if !contains(t, out, "IDLE") {
-		t.Fatal("top bar should contain state")
-	}
 }
 
-func TestRenderTopBar_Running(t *testing.T) {
+func TestRenderTopBar_ShowsCC(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.running = true
-	m.elapsed = 2 * time.Second
-	m.results = []model.Result{
-		{Status: 200, Latency: 100 * time.Millisecond},
-	}
 	out := m.renderTopBar(100)
-	if !contains(t, out, "RUNNING") {
-		t.Fatal("top bar should show RUNNING state")
-	}
-	if !contains(t, out, "1 req") {
-		t.Fatal("top bar should show request count")
-	}
-}
-
-func TestRenderTopBar_Completed(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.status = "COMPLETE"
-	m.elapsed = 5 * time.Second
-	m.results = []model.Result{
-		{Status: 200, Latency: 100 * time.Millisecond},
-	}
-	out := m.renderTopBar(100)
-	if !contains(t, out, "COMPLETED") {
-		t.Fatal("top bar should show COMPLETED state")
-	}
-	if !contains(t, out, "1 req") {
-		t.Fatal("top bar should show request count on completion")
-	}
-}
-
-func TestRenderTopBar_Cancelled(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.status = "CANCELLED"
-	out := m.renderTopBar(100)
-	if !contains(t, out, "CANCELLED") {
-		t.Fatal("top bar should show CANCELLED state via renderTopBarStatus")
-	}
 	if !contains(t, out, "CC") {
-		t.Fatal("top bar should show CC when status is CANCELLED")
-	}
-}
-
-func TestRenderTopBar_StatusError(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.status = "ERROR: connection refused"
-	out := m.renderTopBar(100)
-	if !contains(t, out, "ERROR") {
-		t.Fatal("top bar should show ERROR status via renderTopBarStatus")
-	}
-}
-
-func TestRenderTopBar_IdleDefault(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.status = "SYSTEM READY"
-	out := m.renderTopBar(100)
-	if !contains(t, out, "IDLE") {
-		t.Fatal("top bar should show IDLE when status is SYSTEM READY")
-	}
-	if !contains(t, out, "CC") {
-		t.Fatal("top bar should show CC when idle")
-	}
-}
-
-func TestRenderTopBar_Inspecting(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.mode = modeInspect
-	m.results = []model.Result{
-		{Status: 200, Latency: 100 * time.Millisecond},
-	}
-	m.selected = 0
-	out := m.renderTopBar(100)
-	if !contains(t, out, "INSPECTING") {
-		t.Fatal("top bar should show INSPECTING state")
-	}
-}
-
-func TestRenderTopBar_QuitConfirm(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.dialog = dialogConfirmQuit
-	out := m.renderTopBar(100)
-	if !contains(t, out, "QUIT?") {
-		t.Fatal("top bar should show QUIT? confirmation")
+		t.Fatal("top bar should show CC")
 	}
 }
 
@@ -171,7 +125,7 @@ func TestRenderTopBar_QueryTruncation(t *testing.T) {
 	}
 }
 
-func TestRenderMetrics(t *testing.T) {
+func TestMetricsString(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
@@ -183,7 +137,7 @@ func TestRenderMetrics(t *testing.T) {
 	m.summary.MaxLatency = 500 * time.Millisecond
 	m.elapsed = 5 * time.Second
 
-	out := m.renderMetrics(100)
+	out := m.metricsString()
 	if !contains(t, out, "90% ok") {
 		t.Fatal("metrics should show success rate")
 	}
@@ -196,24 +150,18 @@ func TestRenderMetrics(t *testing.T) {
 	if !contains(t, out, "p99") {
 		t.Fatal("metrics should show p99 latency")
 	}
-	if contains(t, out, "p50") {
-		t.Fatal("metrics should not show p50 latency")
-	}
-	if contains(t, out, "req") {
-		t.Fatal("metrics should not show request count")
-	}
 }
 
-func TestRenderMetrics_Zero(t *testing.T) {
+func TestMetricsString_Zero(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderMetrics(100)
+	out := m.metricsString()
 	if out != "" {
 		t.Fatal("idle metrics with no results should be empty")
 	}
 }
 
-func TestRenderMetrics_HiddenWhenIdle(t *testing.T) {
+func TestMetricsString_HiddenWhenIdle(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = false
@@ -221,19 +169,19 @@ func TestRenderMetrics_HiddenWhenIdle(t *testing.T) {
 	m.summary.SuccessRate = 0
 	m.elapsed = 0
 
-	out := m.renderMetrics(100)
+	out := m.metricsString()
 	if out != "" {
 		t.Fatal("metrics should be hidden when idle with no results")
 	}
 
 	m.running = true
-	out = m.renderMetrics(100)
+	out = m.metricsString()
 	if out == "" {
 		t.Fatal("metrics should appear when running even with no results")
 	}
 }
 
-func TestRenderMetrics_ErrorColor(t *testing.T) {
+func TestMetricsString_Values(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
@@ -242,24 +190,20 @@ func TestRenderMetrics_ErrorColor(t *testing.T) {
 	m.summary.SuccessRate = 100
 	m.elapsed = 5 * time.Second
 
-	outNoErrors := m.renderMetrics(100)
-	if !contains(t, outNoErrors, "100% ok") {
-		t.Fatal("metrics should show 100% ok")
+	out := m.metricsString()
+	if !contains(t, out, "100% ok") {
+		t.Fatal("100% success rate should show '100% ok'")
 	}
 
-	m.summary.Successes = 7
-	m.summary.SuccessRate = 70
-	outWithErrors := m.renderMetrics(100)
-	if !contains(t, outWithErrors, "70% ok") {
-		t.Fatal("metrics with errors should show 70% ok")
-	}
-
-	if outNoErrors == outWithErrors {
-		t.Fatal("different success rates should produce different output")
+	m.summary.Successes = 9
+	m.summary.SuccessRate = 90
+	out = m.metricsString()
+	if !contains(t, out, "90% ok") {
+		t.Fatal("90% success rate should show '90% ok'")
 	}
 }
 
-func TestRenderMetrics_RunningRPS(t *testing.T) {
+func TestMetricsString_RunningRPS(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
@@ -271,13 +215,13 @@ func TestRenderMetrics_RunningRPS(t *testing.T) {
 	m.summary.P99 = 500 * time.Millisecond
 	m.summary.MaxLatency = 500 * time.Millisecond
 
-	out := m.renderMetrics(100)
+	out := m.metricsString()
 	if !contains(t, out, "95% ok") {
 		t.Fatal("metrics should show success rate")
 	}
 }
 
-func TestRenderMetrics_RunningEmpty(t *testing.T) {
+func TestMetricsString_RunningEmpty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
@@ -285,7 +229,7 @@ func TestRenderMetrics_RunningEmpty(t *testing.T) {
 	m.summary.Total = 0
 	m.summary.SuccessRate = 0
 
-	out := m.renderMetrics(100)
+	out := m.metricsString()
 	if out == "" {
 		t.Fatal("metrics should appear when running, even with zero results")
 	}
@@ -294,39 +238,6 @@ func TestRenderMetrics_RunningEmpty(t *testing.T) {
 	}
 	if !contains(t, out, "r/s") {
 		t.Fatal("running empty metrics should show r/s")
-	}
-}
-
-func TestRenderTabs(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	out := m.renderTabStrip(100)
-	if !contains(t, out, "Timeline") {
-		t.Fatal("tab strip should contain 'Timeline'")
-	}
-	if !contains(t, out, "Logs") {
-		t.Fatal("tab strip should contain 'Logs'")
-	}
-}
-
-func TestRenderTabs_ActiveMarker(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	out := m.renderTabStrip(100)
-	if !contains(t, out, "▶ Timeline") {
-		t.Fatal("tab strip should show ▶ marker on active Timeline tab")
-	}
-	if !contains(t, out, "  Logs") {
-		t.Fatal("tab strip should show inactive Logs tab without marker")
-	}
-
-	m.view = viewLogs
-	out = m.renderTabStrip(100)
-	if !contains(t, out, "▶ Logs") {
-		t.Fatal("tab strip should show ▶ marker on active Logs tab")
-	}
-	if !contains(t, out, "  Timeline") {
-		t.Fatal("tab strip should show inactive Timeline tab without marker")
 	}
 }
 
@@ -384,8 +295,23 @@ func TestRenderStatusBar_QuitConfirm(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogConfirmQuit
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "PRESS Q AGAIN TO QUIT") {
+	if !contains(t, out, "quit") {
 		t.Fatal("status bar should show quit confirmation")
+	}
+}
+
+func TestRenderTimeline_Identity(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+	}
+	m.summary.MaxLatency = 100 * time.Millisecond
+	m.selected = 0
+
+	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("timeline should show identity header")
 	}
 }
 
@@ -393,6 +319,9 @@ func TestRenderTimeline_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("empty timeline should show Timeline identity")
+	}
 	if !contains(t, out, "▶  Ctrl+R to run") {
 		t.Fatal("empty timeline should show '▶  Ctrl+R to run'")
 	}
@@ -420,10 +349,28 @@ func TestRenderTimeline_Rows(t *testing.T) {
 	}
 }
 
+func TestRenderLogs_Identity(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond, RequestMethod: "GET", RequestURL: "https://example.com/api"},
+	}
+	m.summary.MaxLatency = 100 * time.Millisecond
+	m.selected = 0
+
+	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Logs") {
+		t.Fatal("logs should show identity header")
+	}
+}
+
 func TestRenderLogs_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Logs") {
+		t.Fatal("empty logs should show Logs identity")
+	}
 	if !contains(t, out, "▶  Ctrl+R to run") {
 		t.Fatal("empty logs should show '▶  Ctrl+R to run'")
 	}
@@ -458,6 +405,23 @@ func TestRenderLogs_Rows(t *testing.T) {
 	}
 }
 
+func TestRenderInspect_Identity(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+	}
+
+	out := m.renderInspect(40, 20)
+	if !contains(t, out, "Inspector") {
+		t.Fatal("inspector should show identity header")
+	}
+	if !contains(t, out, "Result #1") {
+		t.Fatal("inspector should show result number")
+	}
+}
+
 func TestRenderInspect_NoSelection(t *testing.T) {
 	m := NewModel()
 	m.width = 100
@@ -483,9 +447,6 @@ func TestRenderInspect_WithResult(t *testing.T) {
 	}
 
 	out := m.renderInspect(40, 20)
-	if !contains(t, out, "INSPECTOR") {
-		t.Fatal("inspector should show 'INSPECTOR'")
-	}
 	if !contains(t, out, "200") {
 		t.Fatal("inspector should show status")
 	}
@@ -497,6 +458,85 @@ func TestRenderInspect_WithResult(t *testing.T) {
 	}
 	if !contains(t, out, "application/json") {
 		t.Fatal("inspector should show header values")
+	}
+}
+
+func TestRenderInspect_NoMetrics(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.selected = 0
+	m.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+	}
+	m.summary.Total = 50
+	m.summary.SuccessRate = 90
+	m.elapsed = 5 * time.Second
+
+	out := m.renderInspect(40, 20)
+	if contains(t, out, "% ok") {
+		t.Fatal("inspector should NOT show aggregate metrics")
+	}
+	if contains(t, out, "r/s") {
+		t.Fatal("inspector should NOT show requests per second")
+	}
+}
+
+func TestRenderInspect_WithError(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  500,
+			Latency: 100 * time.Millisecond,
+			Error:   "connection refused",
+		},
+	}
+
+	out := m.renderInspect(40, 20)
+	if !contains(t, out, "connection refused") {
+		t.Fatal("inspector should show error message")
+	}
+	if !contains(t, out, "Error:") {
+		t.Fatal("inspector should show 'Error:' prefix")
+	}
+}
+
+func TestRenderInspect_NoHeaders(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+		},
+	}
+
+	out := m.renderInspect(40, 20)
+	if !contains(t, out, "No headers captured.") {
+		t.Fatal("inspector should show 'No headers captured.' when no response headers")
+	}
+}
+
+func TestRenderInspect_NoBody(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+
+	out := m.renderInspect(40, 20)
+	if !contains(t, out, "No body captured.") {
+		t.Fatal("inspector should show 'No body captured.' when no response body")
 	}
 }
 
@@ -586,6 +626,9 @@ func TestRenderTimeline_RunningEmpty(t *testing.T) {
 	m.status = "RUNNING"
 
 	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("running empty timeline should show Timeline identity")
+	}
 	if !contains(t, out, "⏳  Waiting for results...") {
 		t.Fatal("running empty timeline should show '⏳  Waiting for results...'")
 	}
@@ -598,6 +641,9 @@ func TestRenderTimeline_IdleNoURL(t *testing.T) {
 	m.urlInput.SetValue("")
 
 	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("idle empty timeline should show Timeline identity")
+	}
 	if !contains(t, out, "Enter a URL to begin") {
 		t.Fatal("idle empty timeline with no URL should show 'Enter a URL to begin'")
 	}
@@ -610,6 +656,9 @@ func TestRenderTimeline_IdleWithURL(t *testing.T) {
 	m.urlInput.SetValue("https://example.com/api")
 
 	out := m.renderTimeline(94, 20)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("idle empty timeline should show Timeline identity")
+	}
 	if !contains(t, out, "▶  Ctrl+R to run") {
 		t.Fatal("idle empty timeline with URL should show '▶  Ctrl+R to run'")
 	}
@@ -622,6 +671,9 @@ func TestRenderLogs_RunningEmpty(t *testing.T) {
 	m.status = "RUNNING"
 
 	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Logs") {
+		t.Fatal("running empty logs should show Logs identity")
+	}
 	if !contains(t, out, "📭  No results yet...") {
 		t.Fatal("running empty logs should show '📭  No results yet...'")
 	}
@@ -634,6 +686,9 @@ func TestRenderLogs_IdleNoURL(t *testing.T) {
 	m.urlInput.SetValue("")
 
 	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Logs") {
+		t.Fatal("idle empty logs should show Logs identity")
+	}
 	if !contains(t, out, "Enter a URL to begin") {
 		t.Fatal("idle empty logs with no URL should show 'Enter a URL to begin'")
 	}
@@ -646,69 +701,11 @@ func TestRenderLogs_IdleWithURL(t *testing.T) {
 	m.urlInput.SetValue("https://example.com/api")
 
 	out := m.renderLogs(94, 20)
+	if !contains(t, out, "Logs") {
+		t.Fatal("idle empty logs should show Logs identity")
+	}
 	if !contains(t, out, "▶  Ctrl+R to run") {
 		t.Fatal("idle empty logs with URL should show '▶  Ctrl+R to run'")
-	}
-}
-
-func TestRenderInspect_WithError(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.selected = 0
-	m.results = []model.Result{
-		{
-			Status:  500,
-			Latency: 100 * time.Millisecond,
-			Error:   "connection refused",
-		},
-	}
-
-	out := m.renderInspect(40, 20)
-	if !contains(t, out, "INSPECTOR") {
-		t.Fatal("inspector should show 'INSPECTOR'")
-	}
-	if !contains(t, out, "connection refused") {
-		t.Fatal("inspector should show error message")
-	}
-	if !contains(t, out, "Error:") {
-		t.Fatal("inspector should show 'Error:' prefix")
-	}
-}
-
-func TestRenderInspect_NoHeaders(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.selected = 0
-	m.results = []model.Result{
-		{
-			Status:  200,
-			Latency: 100 * time.Millisecond,
-		},
-	}
-
-	out := m.renderInspect(40, 20)
-	if !contains(t, out, "No headers captured.") {
-		t.Fatal("inspector should show 'No headers captured.' when no response headers")
-	}
-}
-
-func TestRenderInspect_NoBody(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.selected = 0
-	m.results = []model.Result{
-		{
-			Status:  200,
-			Latency: 100 * time.Millisecond,
-			ResponseHeaders: map[string]string{
-				"Content-Type": "application/json",
-			},
-		},
-	}
-
-	out := m.renderInspect(40, 20)
-	if !contains(t, out, "No body captured.") {
-		t.Fatal("inspector should show 'No body captured.' when no response body")
 	}
 }
 
@@ -720,9 +717,6 @@ func TestView_WidthMinClamp(t *testing.T) {
 	out := m.View()
 	if !contains(t, out, "GET") {
 		t.Fatal("View should contain method even at small width")
-	}
-	if !contains(t, out, "IDLE") {
-		t.Fatal("View should show state even at small width")
 	}
 }
 
@@ -740,7 +734,7 @@ func TestView_PayloadNotShown(t *testing.T) {
 	}
 }
 
-func TestRenderPayload_Open(t *testing.T) {
+func TestRenderPayload_Identity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.dialog = dialogPayload
@@ -750,6 +744,9 @@ func TestRenderPayload_Open(t *testing.T) {
 	m.headers[0].Value.SetValue("application/json")
 
 	out := m.renderPayload(96)
+	if !contains(t, out, "Payload") {
+		t.Fatal("payload should show identity header")
+	}
 	if !contains(t, out, "HEADERS") {
 		t.Fatal("payload should contain 'HEADERS'")
 	}
@@ -771,6 +768,9 @@ func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 	m.selectedHead = 0
 
 	out := m.renderPayload(96)
+	if !contains(t, out, "Payload") {
+		t.Fatal("payload should show identity header")
+	}
 	if !contains(t, out, "No headers configured.") {
 		t.Fatal("payload should show 'No headers configured.' when no headers")
 	}
@@ -786,12 +786,49 @@ func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	m.headers[0].Value.SetValue("application/json")
 
 	out := m.renderPayload(96)
+	if !contains(t, out, "Payload") {
+		t.Fatal("payload should show identity header")
+	}
 	if !contains(t, out, `{"name":"pulse"}`) {
 		t.Fatal("payload should show body placeholder when body is empty")
 	}
 }
 
-func TestRenderWorkspace_InspectorStacked(t *testing.T) {
+func TestRenderEndpoint_Identity(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderEndpoint(100)
+	if !contains(t, out, "Endpoint") {
+		t.Fatal("endpoint should show identity header")
+	}
+	if !contains(t, out, "URL") {
+		t.Fatal("endpoint editor should show URL label")
+	}
+	if !contains(t, out, "Method") {
+		t.Fatal("endpoint editor should show Method label")
+	}
+	if !contains(t, out, "GET") {
+		t.Fatal("endpoint editor should show method options")
+	}
+}
+
+func TestRenderConcurrency_Identity(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.setConcurrency(7)
+	out := m.renderConcurrency(100)
+	if !contains(t, out, "Concurrency") {
+		t.Fatal("concurrency should show identity header")
+	}
+	if !contains(t, out, "7") {
+		t.Fatal("concurrency editor should show current value")
+	}
+	if !contains(t, out, "1–100") {
+		t.Fatal("concurrency should show range affordance")
+	}
+}
+
+func TestRenderWorkspace_InspectorDrillDown(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.height = 30
@@ -804,40 +841,14 @@ func TestRenderWorkspace_InspectorStacked(t *testing.T) {
 	m.selected = 0
 
 	out := m.View()
-	if !contains(t, out, "INSPECTOR") {
-		t.Fatal("workspace with inspector should show INSPECTOR")
+	if !contains(t, out, "Inspector") {
+		t.Fatal("workspace with inspector should show Inspector header")
 	}
-	if !contains(t, out, "Timeline") {
-		t.Fatal("workspace should show Timeline tab")
+	if !contains(t, out, "Result #1") {
+		t.Fatal("workspace with inspector should show result number")
 	}
 	if !contains(t, out, "200") {
 		t.Fatal("workspace should show result status")
-	}
-}
-
-func TestRenderMetrics_SuccessColor(t *testing.T) {
-	m := NewModel()
-	m.width = 100
-	m.running = true
-	m.summary.Total = 10
-	m.summary.Successes = 10
-	m.summary.SuccessRate = 100
-	m.elapsed = 5 * time.Second
-
-	out100 := m.renderMetrics(100)
-	if !contains(t, out100, "100% ok") {
-		t.Fatal("100% success rate should show '100% ok'")
-	}
-
-	m.summary.Successes = 9
-	m.summary.SuccessRate = 90
-	out90 := m.renderMetrics(100)
-	if !contains(t, out90, "90% ok") {
-		t.Fatal("90% success rate should show '90% ok'")
-	}
-
-	if out100 == out90 {
-		t.Fatal("different success rates should produce different output")
 	}
 }
 
@@ -856,5 +867,26 @@ func TestRenderTimeline_Rows_Selected(t *testing.T) {
 	}
 	if !contains(t, row, "▶") {
 		t.Fatal("selected row should show cursor")
+	}
+}
+
+func TestVisibleWindow(t *testing.T) {
+	tt := []struct {
+		total    int
+		selected int
+		height   int
+		expected int
+	}{
+		{0, 0, 10, 0},
+		{5, 2, 10, 0},
+		{10, 5, 5, 3},
+		{10, 9, 5, 5},
+		{10, 0, 5, 0},
+	}
+	for _, tc := range tt {
+		got := visibleWindow(tc.total, tc.selected, tc.height)
+		if got != tc.expected {
+			t.Errorf("visibleWindow(%d,%d,%d) = %d (expected %d)", tc.total, tc.selected, tc.height, got, tc.expected)
+		}
 	}
 }


### PR DESCRIPTION
Adds Ready launch pad as the first-run surface (replaces empty timeline) so Pulse no longer launches into an observation surface before observation exists.

Architecture changes:
- Ready renderer: centered launch pad with URL, CC, run CTA, action links. No branding, no tips, no metrics. Disappears after first run.
- Workspace-owned identity: each renderer emits its own identity line (Timeline, Logs, Inspector - Result #N, Endpoint, Concurrency, Payload) instead of View() rendering a shared header.
- Metrics separated from identity: metrics are the first body row in Timeline/Logs only. Inspector has no aggregate metrics.
- visibleWindow() helper extracted: deduplicates scroll-window logic between Timeline and Logs.
- Concurrency range affordance: shows (1-100) to make adjustability discoverable.

Post-implementation audit corrections:
- Ready CTA reordered: Press Ctrl+R to run now appears above URL so the primary action is the visual center of gravity.
- Status bar hints: [ ] -> [ ] views so view switching is self- describing to first-time users.

Deleted:
- renderWorkspaceHeader() and workspaceHeaderText()
- renderMetrics() (replaced by metricsString())
- renderTabStrip()
- renderTopBarStatus(), renderRightStyled()
- 7 TestWorkspaceHeader_* tests
- All old multi-column inspector/timeline layout code from View()

Fixes:
- Status bar hints shortened and made contextual
- Inspector identity changed from 'INSPECTOR' section header to 'Inspector - Result #N' identity line
- Concurrency editor now shows identity header
- Payload/Endpoint editors now show identity header
- Terminology: README 'command bar' -> 'Ready launch pad'

Canonical surfaces:
  Ready:    Context / Ready body / Interaction
  Observe:  Context / Identity / Metrics + Results / Interaction
  Inspect:  Context / Identity / Details / Interaction