### PR TITLE
v0.7.8: Operator Baseline - payload visibility, notation normalization, renderer consolidation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -203,3 +203,58 @@ Pulse/
 ├── web/                   # SolidJS frontend source
 └── .github/workflows/     # CI and release pipelines
 ```
+
+## Renderer Architecture (v0.7.7+)
+
+The terminal UI follows a strict four-layer ownership model:
+
+| Layer | Role | Renderers |
+|---|---|---|
+| Context | Persistent state frame | Top bar (method, URL, CC) |
+| Identity | Workspace identification | Timeline, Logs, Inspector - Result #N, Endpoint, Concurrency, Payload |
+| Content | Primary data display | Metrics, result rows, dialog forms, response details |
+| Interaction | Immediate action signals | Status bar mode + hints, ConfirmQuit |
+
+Each workspace surface owns exactly one identity line:
+
+| Surface | Identity | Style |
+|---|---|---|
+| Ready | None (launch state) | N/A |
+| Timeline | `Timeline` | Bold + Accent |
+| Logs | `Logs` | Bold + Accent |
+| Inspector | `Inspector - Result #N` | Bold + Accent |
+| Endpoint | `Endpoint` | Muted |
+| Concurrency | `Concurrency` | Muted |
+| Payload | `Payload` | Muted |
+
+ConfirmQuit is an interaction-layer dialog only - it preserves the current workspace identity and content, changing only the status bar.
+
+### Visual Invariant (v0.7.8+)
+
+| Concept | Representation |
+|---|---|
+| Cursor (navigation position) | `▶` glyph |
+| Highlight (active target) | Accent foreground + dark background |
+
+All selection-capable surfaces follow this invariant:
+
+| Surface | Cursor | Highlight |
+|---|---|---|
+| Timeline | ✓ | ✓ |
+| Logs | ✓ | ✓ |
+| Payload header rows | ✓ | ✓ |
+| Payload body | N/A | ✓ |
+| Endpoint method selector | ✓ | ✓ |
+| Concurrency value | ✓ | ✓ |
+| Inspector | N/A | N/A (read-only) |
+
+### Renderer Dispatch
+
+`View()` is a pure dispatch function:
+
+1. Compute width and body height.
+2. Dispatch to the correct renderer based on dialog, mode, and state.
+3. Compose the layout: Top bar → Separator → Body → Separator → Status bar.
+4. Wrap in base style with explicit width and height.
+
+No renderer performs another renderer's work. No rendering logic lives in `View()`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Design principles:
 1. Set URL, method, and concurrency.
 2. Optionally configure headers and body.
 3. Run and watch each request stream in real time.
-4. Click any result to inspect full response details.
+4. Select any result and press Enter to inspect full response details.
 
 ## Documentation Map
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -898,3 +898,37 @@ func TestCCDialog_ClampAtMin(t *testing.T) {
 		t.Fatalf("concurrency at min should stay 1, got %d", m.concurrency())
 	}
 }
+
+// Freezes the current Inspect navigation contract for v0.8.x discussion.
+func TestInspectNavigationChangesSelection(t *testing.T) {
+	m := NewModel()
+	m.mode = modeInspect
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+		{Status: 404, Latency: 20 * time.Millisecond},
+		{Status: 500, Latency: 30 * time.Millisecond},
+	}
+	m.selected = 1
+
+	// Up arrow should move selection up
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.selected != 0 {
+		t.Fatalf("up in inspect: selected = %d, want 0", m.selected)
+	}
+
+	// Down arrow should move selection down
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if m.selected != 1 {
+		t.Fatalf("down in inspect: selected = %d, want 1", m.selected)
+	}
+
+	// Down at last result should stay
+	m.selected = 2
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if m.selected != 2 {
+		t.Fatalf("down at last in inspect: selected = %d, want 2", m.selected)
+	}
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -161,7 +161,7 @@ func (m Model) renderPayload(width int) string {
 	if len(m.headers) == 0 {
 		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("  No headers configured."))
 	} else {
-		for _, header := range m.headers {
+		for i, header := range m.headers {
 			key := header.Key.Value()
 			value := header.Value.Value()
 			if key == "" {
@@ -170,7 +170,11 @@ func (m Model) renderPayload(width int) string {
 			if value == "" {
 				value = "Value"
 			}
-			b.WriteString(fmt.Sprintf("  %s: %s\n", key, value))
+			sel := i == m.selectedHead
+			cursor := rowCursor(sel)
+			line := fmt.Sprintf("%s %s: %s", cursor, key, value)
+			b.WriteString(rowStyle(sel).Render(line))
+			b.WriteString("\n")
 		}
 	}
 
@@ -206,22 +210,22 @@ func (m Model) renderStatusBar(width int) string {
 		hints = "q/Ctrl+C again to quit, any key cancels"
 	case m.dialog == dialogEndpoint:
 		mode = "ENDPOINT"
-		hints = "• ESC • ↵"
+		hints = "• Esc • ↵"
 	case m.dialog == dialogConcurrency:
 		mode = "CONCURRENCY"
-		hints = "• ↑↓ • ESC"
+		hints = "• ↑↓ • Esc"
 	case m.dialog == dialogPayload:
 		mode = "PAYLOAD"
-		hints = "• ESC"
+		hints = "• Esc"
 	case m.mode == modeInspect:
 		mode = "INSPECTING"
-		hints = "• ↑↓ • ESC • Q"
+		hints = "• ↑↓ • Esc • q"
 	case m.running:
 		mode = "RUNNING"
-		hints = "• ↑↓ • ENTER • ^X • Q"
+		hints = "• ↑↓ • Enter • Ctrl+X • q"
 	default:
 		mode = "OBSERVE"
-		hints = "• ↑↓ • ENTER • [ ] views • e • c • p • ^R • Q"
+		hints = "• ↑↓ • Enter • [ ] views • e • c • p • Ctrl+R • q"
 	}
 
 	if mode == "" {
@@ -249,10 +253,10 @@ func visibleWindow(total, selected, height int) int {
 	return start
 }
 
-func (m Model) renderTimeline(width int, height int) string {
+func (m Model) renderResultList(width, height int, identity string, emptyRunning string, rowFn func(result model.Result, index int, selected bool, width int) string) string {
 	var b strings.Builder
 
-	b.WriteString(identityCell("Timeline", false))
+	b.WriteString(identityCell(identity, false))
 	b.WriteString("\n")
 
 	remaining := height - 1
@@ -267,7 +271,7 @@ func (m Model) renderTimeline(width int, height int) string {
 	}
 
 	if len(m.results) == 0 {
-		msg := m.renderEmptyState("⏳  Waiting for results...")
+		msg := m.renderEmptyState(emptyRunning)
 		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(msg))
 		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
 	}
@@ -277,11 +281,18 @@ func (m Model) renderTimeline(width int, height int) string {
 	for i := start; i < len(m.results) && len(rows) < remaining; i++ {
 		result := m.results[i]
 		sel := i == m.selected
-		rows = append(rows, m.renderTimelineRow(i, result, m.summary.MaxLatency, width, sel))
+		rows = append(rows, rowFn(result, i, sel, width))
 	}
 	b.WriteString(strings.Join(rows, "\n"))
 
 	return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+}
+
+func (m Model) renderTimeline(width int, height int) string {
+	return m.renderResultList(width, height, "Timeline", "⏳  Waiting for results...",
+		func(result model.Result, index int, selected bool, width int) string {
+			return m.renderTimelineRow(index, result, m.summary.MaxLatency, width, selected)
+		})
 }
 
 func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time.Duration, width int, selected bool) string {
@@ -316,53 +327,24 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 }
 
 func (m Model) renderLogs(width int, height int) string {
-	var b strings.Builder
-
-	b.WriteString(identityCell("Logs", false))
-	b.WriteString("\n")
-
-	remaining := height - 1
-	if metrics := m.metricsString(); metrics != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Render(metrics))
-		b.WriteString("\n")
-		remaining--
-	}
-
-	if remaining <= 0 {
-		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
-	}
-
-	if len(m.results) == 0 {
-		msg := m.renderEmptyState("📭  No results yet...")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(msg))
-		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
-	}
-
-	start := visibleWindow(len(m.results), m.selected, remaining)
-	rows := make([]string, 0, min(len(m.results)-start, remaining))
-	for i := start; i < len(m.results) && len(rows) < remaining; i++ {
-		result := m.results[i]
-		sel := i == m.selected
-		status := resultStatus(result)
-		method := result.RequestMethod
-		if method == "" {
-			method = runconfig.AllowedMethods()[m.methodIndex]
-		}
-		reqURL := result.RequestURL
-		if reqURL == "" {
-			reqURL = m.urlInput.Value()
-		}
-		line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
-			rowCursor(sel), i+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
-		if result.Status >= 400 || result.Status == 0 {
-			rows = append(rows, strings.TrimSpace(errorRowStyle(sel).Render(truncate(line, width))))
-		} else {
-			rows = append(rows, strings.TrimSpace(rowStyle(sel).Render(truncate(line, width))))
-		}
-	}
-	b.WriteString(strings.Join(rows, "\n"))
-
-	return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+	return m.renderResultList(width, height, "Logs", "📭  No results yet...",
+		func(result model.Result, index int, selected bool, width int) string {
+			status := resultStatus(result)
+			method := result.RequestMethod
+			if method == "" {
+				method = runconfig.AllowedMethods()[m.methodIndex]
+			}
+			reqURL := result.RequestURL
+			if reqURL == "" {
+				reqURL = m.urlInput.Value()
+			}
+			line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
+				rowCursor(selected), index+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
+			if result.Status >= 400 || result.Status == 0 {
+				return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
+			}
+			return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
+		})
 }
 
 func (m Model) renderInspect(width int, height int) string {
@@ -380,11 +362,13 @@ func (m Model) renderInspect(width int, height int) string {
 		reqURL = m.urlInput.Value()
 	}
 
-	sectionHeader := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(colorAccent))
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	errorText := lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
+	sectionLine := func(label string) string {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("-- " + label + " --")
+	}
 
-	identity := identityCell(fmt.Sprintf("Inspector — Result #%d", m.selected+1), false)
+	identity := identityCell(fmt.Sprintf("Inspector - Result #%d", m.selected+1), false)
 
 	lines := []string{
 		identity,
@@ -397,7 +381,7 @@ func (m Model) renderInspect(width int, height int) string {
 	if result.Error != "" {
 		lines = append(lines, errorText.Render("Error: "+result.Error))
 	}
-	lines = append(lines, "", sectionHeader.Render("HEADERS"))
+	lines = append(lines, "", sectionLine("HEADERS"))
 
 	if len(result.ResponseHeaders) == 0 {
 		lines = append(lines, muted.Render("No headers captured."))
@@ -412,7 +396,7 @@ func (m Model) renderInspect(width int, height int) string {
 		}
 	}
 
-	lines = append(lines, "", sectionHeader.Render("BODY"))
+	lines = append(lines, "", sectionLine("BODY"))
 	body := result.ResponseBody
 	if body == "" {
 		body = muted.Render("No body captured.")

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -870,6 +870,73 @@ func TestRenderTimeline_Rows_Selected(t *testing.T) {
 	}
 }
 
+func TestRenderPayload_SelectedRowVisible(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogPayload
+	m.headers = append(m.headers, newHeaderRow(), newHeaderRow(), newHeaderRow())
+	m.headers[0].Key.SetValue("Authorization")
+	m.headers[0].Value.SetValue("Bearer token")
+	m.headers[1].Key.SetValue("Content-Type")
+	m.headers[1].Value.SetValue("application/json")
+	m.selectedHead = 1
+
+	out := m.renderPayload(96)
+	if !contains(t, out, "Authorization") {
+		t.Fatal("payload should show first header key")
+	}
+	if !contains(t, out, "Content-Type") {
+		t.Fatal("payload should show second header key")
+	}
+	// selected row should have cursor
+	if !contains(t, out, "▶ Content-Type") {
+		t.Fatal("selected header row should show ▶ cursor")
+	}
+}
+
+func TestRenderPayload_BodyFocusColor(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogPayload
+	m.selectedHead = bodyFocus
+	m.headers = append(m.headers, newHeaderRow())
+
+	out := m.renderPayload(96)
+	if !contains(t, out, "BODY") {
+		t.Fatal("payload should show BODY label")
+	}
+}
+
+func TestRenderStatusBar_PayloadDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogPayload
+	out := m.renderStatusBar(100)
+	if !contains(t, out, "PAYLOAD") {
+		t.Fatal("status bar should show 'PAYLOAD' mode")
+	}
+	if !contains(t, out, "Esc") {
+		t.Fatal("status bar should show 'Esc' in payload mode")
+	}
+}
+
+func TestConfirmQuit_PreservesWorkspace(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	m.running = true
+	m.dialog = dialogConfirmQuit
+
+	out := m.View()
+	if !contains(t, out, "Ctrl+C") {
+		t.Fatal("confirm quit should show ctrl+c prompt")
+	}
+	// Body content should still be visible (Timeline identity preserved)
+	if !contains(t, out, "Timeline") {
+		t.Fatal("confirm quit should preserve workspace identity")
+	}
+}
+
 func TestVisibleWindow(t *testing.T) {
 	tt := []struct {
 		total    int


### PR DESCRIPTION
P0 - Operator Correctness
- Payload selection semantics: add cursor + accent/highlight to selected header row. Both signals (cursor=position, highlight=active).
- Footer notation normalization: Title Case for named keys (Enter, Esc, Ctrl+R, Ctrl+X), lowercase for single-letter actions (q, e, c, p).

P1 - Canonicalization
- Timeline/Logs renderer extraction: extract shared renderResultList() with identity, metrics, empty state, visible-window, and row iteration owned by the shared renderer. Thin wrappers remain for view-specific row formatting.
- Inspector hierarchy: replace competing bold+accent section headers with muted -- HEADERS -- / -- BODY -- separators. Identity line remains dominant.
- Architecture docs: document four-layer ownership model (Context / Identity / Content / Interaction), visual invariant table (cursor=position, highlight=active), and renderer dispatch contract.
- README cleanup: 'Click any result to inspect' to 'Select any result and press Enter to inspect'.

P2 - Verification
- Test gaps: add TestInspectNavigationChangesSelection (freezes current Inspect navigation contract), TestRenderPayload_SelectedRowVisible, TestRenderPayload_BodyFocusColor, TestRenderStatusBar_PayloadDialog, TestConfirmQuit_PreservesWorkspace.
- Renderer ownership audit: View() confirmed as dispatch-only.
- Canonicalization audit: extraction resolved the main structural duplication; remaining inline styles and test patterns are intentional.

Architecture preserved. No new states, dialogs, keybindings, or render surfaces. All existing tests pass. Race clean. Vet clean. Build clean.