### PR TITLE
v0.7.9: Audit Corrections - Ready status bar truthfulness

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -223,6 +223,9 @@ func (m Model) renderStatusBar(width int) string {
 	case m.running:
 		mode = "RUNNING"
 		hints = "• ↑↓ • Enter • Ctrl+X • q"
+	case !m.running && len(m.results) == 0:
+		mode = "OBSERVE"
+		hints = "• e • c • p • Ctrl+R • q"
 	default:
 		mode = "OBSERVE"
 		hints = "• ↑↓ • Enter • [ ] views • e • c • p • Ctrl+R • q"

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -244,9 +244,37 @@ func TestMetricsString_RunningEmpty(t *testing.T) {
 func TestRenderStatusBar_Normal(t *testing.T) {
 	m := NewModel()
 	m.width = 100
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderStatusBar(100)
 	if !contains(t, out, "OBSERVE") {
 		t.Fatal("status bar should show 'OBSERVE' mode")
+	}
+	if !contains(t, out, "↑↓") {
+		t.Fatal("post-run status bar should show scroll hint")
+	}
+}
+
+func TestRenderStatusBar_Ready(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderStatusBar(100)
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("ready status bar should show 'OBSERVE' mode")
+	}
+	if contains(t, out, "↑↓") {
+		t.Fatal("ready status bar should not advertise ↑↓ (inert)")
+	}
+	if contains(t, out, "Enter") {
+		t.Fatal("ready status bar should not advertise Enter (inert)")
+	}
+	if contains(t, out, "[ ]") {
+		t.Fatal("ready status bar should not advertise view switching (inert)")
+	}
+	if !contains(t, out, "Ctrl+R") {
+		t.Fatal("ready status bar should show Ctrl+R")
+	}
+	if !contains(t, out, "q") {
+		t.Fatal("ready status bar should show q (quit)")
 	}
 }
 


### PR DESCRIPTION
Fix an objective renderer correctness failure found by the v0.8.0b Operator Experience Audit: the Ready state advertised ↑↓, Enter, and [ ] views in the status bar, but all three are inert in Ready (no results to scroll, inspect, or switch view for).

Added a distinct status bar case for Ready that only advertises actions that actually work (e, c, p, Ctrl+R, q).

Changes:
- renderStatusBar: new case for !running && len(results)==0 (Ready)
- TestRenderStatusBar_Normal: updated to test post-run Observe state
- TestRenderStatusBar_Ready: new test verifying inert controls removed

Validation Ledger C (Status-Bar Truthfulness): FAIL
  - Ready: ↑↓, Enter, [ ] views advertised but inert
Validation Ledger D (Inert-Control Audit): 3 High-severity findings
  - Ready: ↑↓, Enter (High), [ ] views (Medium)

All four admission criteria met:
  - Objective: advertised action does nothing
  - Verifiable: test asserts absence of inert controls
  - Renderer-only: no workflow or interaction changes
  - No new concepts: no new modes, dialogs, views, or keybindings

Canonicalization Ledger J (State Identity Consistency):
  - Root cause: renderStatusBar default case collapses Ready and post-run Observe into one OBSERVE identity despite different meaningful action sets.
  - Fix: separate Ready case restores one-to-one mapping between render state and status bar identity.

DRY review: no further consolidation opportunities found. All renderers, tests, and documentation are consistent. go vet clean, gofmt clean, go test -race clean.