### PR TITLE
v0.8.1: Ready identity and top-anchored layout

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -97,11 +97,17 @@ func (m Model) renderReady(width int, height int) string {
 	url := m.urlInput.Value()
 	cc := m.concurrency()
 
+	identity := identityCell("OBSERVE", false)
+
 	content := fmt.Sprintf("Press Ctrl+R to run\n\n%s %s\n\nCC %d\n\ne Endpoint    c Concurrency    p Payload",
 		method, url, cc)
 
-	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center,
-		lipgloss.NewStyle().Foreground(lipgloss.Color(colorText)).Render(content))
+	var b strings.Builder
+	b.WriteString(identity)
+	b.WriteString("\n\n")
+	b.WriteString(content)
+
+	return StyleBase.Copy().Width(width).Height(height).Render(b.String())
 }
 
 func (m Model) renderEndpoint(width int) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -54,6 +54,9 @@ func TestRenderReady(t *testing.T) {
 	m.width = 100
 	m.height = 30
 	out := m.renderReady(100, 26)
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("Ready should show identity")
+	}
 	if !contains(t, out, "httpbin") {
 		t.Fatal("Ready should show URL")
 	}


### PR DESCRIPTION
Ready now participates in the same renderer structure as the rest of the TUI.

Changes:
- Add OBSERVE as the Ready surface identity
- Replace centered composition with top-anchored rendering
- Separate identity and content composition inside renderReady
- Extend TestRenderReady to verify identity presence

Behavior preserved:
- Context ownership remains in View()
- Interaction ownership remains in View()
- Renderer ownership remains Identity + Content
- Timeline, Logs, Inspect, Payload, Endpoint, Concurrency, and ConfirmQuit are unchanged

The v0.8.0 audit identified Ready as the only surface lacking an identity layer and the only surface using centered composition. This change brings Ready into alignment with the established renderer structure without altering workflows, interactions, visual language, or responsive behavior.

References:
- v0.8.0 Operator Experience Audit
- Ledger G (Canonicalization)
- Ledger H (Cohesion)