### PR TITLE
v0.8.4: Housekeeping - dead code removal, style consolidation, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# local artifacts
+tmp/

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -81,7 +81,6 @@ type Model struct {
 	eventCh   <-chan model.Event
 	status    string
 	errMsg    string
-	capped    bool
 	summary   metrics.Summary
 }
 
@@ -165,8 +164,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		following := m.isFollowingTail()
 		if len(m.results) < 10000 {
 			m.results = append(m.results, msg.Result)
-		} else {
-			m.capped = true
 		}
 		m.summary = metrics.Compute(m.results, m.elapsed)
 		if following {
@@ -523,7 +520,6 @@ func (m Model) startRun() (Model, tea.Cmd) {
 	m.elapsed = 0
 	m.results = nil
 	m.selected = 0
-	m.capped = false
 	m.errMsg = ""
 	m.status = "RUNNING"
 	m.summary = metrics.Summary{}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,11 +14,12 @@ const (
 )
 
 var (
-	StyleBase       = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
-	StyleTopBar     = StyleBase.Copy().Bold(true)
-	StyleStatusBar  = StyleBase.Copy().Background(lipgloss.Color(colorDark))
-	StyleStatusMode = lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorBg)).Bold(true)
-	StyleSeparator  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	styleBase       = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
+	styleTopBar     = styleBase.Copy().Bold(true)
+	styleStatusBar  = styleBase.Copy().Background(lipgloss.Color(colorDark))
+	styleStatusMode = lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorBg)).Bold(true)
+	styleSeparator  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	styleMuted      = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 )
 
 func statusColor(status int) string {

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -30,32 +30,41 @@ func TestColorConstants(t *testing.T) {
 }
 
 func TestStyleBase(t *testing.T) {
-	if got := StyleBase.GetForeground(); got != lipgloss.Color(colorText) {
-		t.Errorf("StyleBase foreground = %q, want %q", got, colorText)
+	if got := styleBase.GetForeground(); got != lipgloss.Color(colorText) {
+		t.Errorf("styleBase foreground = %q, want %q", got, colorText)
 	}
-	if got := StyleBase.GetBackground(); got != lipgloss.Color(colorBg) {
-		t.Errorf("StyleBase background = %q, want %q", got, colorBg)
+	if got := styleBase.GetBackground(); got != lipgloss.Color(colorBg) {
+		t.Errorf("styleBase background = %q, want %q", got, colorBg)
+	}
+	if got := styleBase.GetBackground(); got != lipgloss.Color(colorBg) {
+		t.Errorf("styleBase background = %q, want %q", got, colorBg)
 	}
 }
 
 func TestStyleStatusBar(t *testing.T) {
-	if got := StyleStatusBar.GetForeground(); got != lipgloss.Color(colorText) {
-		t.Errorf("StyleStatusBar foreground = %q, want %q", got, colorText)
+	if got := styleStatusBar.GetForeground(); got != lipgloss.Color(colorText) {
+		t.Errorf("styleStatusBar foreground = %q, want %q", got, colorText)
 	}
-	if got := StyleStatusBar.GetBackground(); got != lipgloss.Color(colorDark) {
-		t.Errorf("StyleStatusBar background = %q, want %q", got, colorDark)
+	if got := styleStatusBar.GetBackground(); got != lipgloss.Color(colorDark) {
+		t.Errorf("styleStatusBar background = %q, want %q", got, colorDark)
 	}
 }
 
 func TestStyleStatusMode(t *testing.T) {
-	if got := StyleStatusMode.GetForeground(); got != lipgloss.Color(colorBg) {
-		t.Errorf("StyleStatusMode foreground = %q, want %q", got, colorBg)
+	if got := styleStatusMode.GetForeground(); got != lipgloss.Color(colorBg) {
+		t.Errorf("styleStatusMode foreground = %q, want %q", got, colorBg)
 	}
-	if got := StyleStatusMode.GetBackground(); got != lipgloss.Color(colorAccent) {
-		t.Errorf("StyleStatusMode background = %q, want %q", got, colorAccent)
+	if got := styleStatusMode.GetBackground(); got != lipgloss.Color(colorAccent) {
+		t.Errorf("styleStatusMode background = %q, want %q", got, colorAccent)
 	}
-	if got := StyleStatusMode.GetBold(); !got {
-		t.Error("StyleStatusMode should be bold")
+	if got := styleStatusMode.GetBold(); !got {
+		t.Error("styleStatusMode should be bold")
+	}
+	if got := styleStatusMode.GetBackground(); got != lipgloss.Color(colorAccent) {
+		t.Errorf("styleStatusMode background = %q, want %q", got, colorAccent)
+	}
+	if got := styleStatusMode.GetBold(); !got {
+		t.Error("styleStatusMode should be bold")
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -22,7 +22,7 @@ func (m Model) View() string {
 	var sb strings.Builder
 	sb.WriteString(m.renderTopBar(width))
 	sb.WriteString("\n")
-	sb.WriteString(StyleSeparator.Render(strings.Repeat("─", width)))
+	sb.WriteString(styleSeparator.Render(strings.Repeat("─", width)))
 	sb.WriteString("\n")
 
 	switch {
@@ -43,16 +43,16 @@ func (m Model) View() string {
 	}
 
 	sb.WriteString("\n")
-	sb.WriteString(StyleSeparator.Render(strings.Repeat("─", width)))
+	sb.WriteString(styleSeparator.Render(strings.Repeat("─", width)))
 	sb.WriteString("\n")
 	sb.WriteString(m.renderStatusBar(width))
 
-	return StyleBase.Width(width).Height(m.height).Render(sb.String())
+	return styleBase.Width(width).Height(m.height).Render(sb.String())
 }
 
 func identityCell(label string, subdued bool) string {
 	if subdued {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(label)
+		return styleMuted.Render(label)
 	}
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true).Render(label)
 }
@@ -89,7 +89,7 @@ func (m Model) renderTopBar(width int) string {
 	}
 
 	line := leftTruncated + strings.Repeat(" ", padding) + right
-	return StyleTopBar.Width(width).Render(line)
+	return styleTopBar.Width(width).Render(line)
 }
 
 func (m Model) renderReady(width int, height int) string {
@@ -107,7 +107,7 @@ func (m Model) renderReady(width int, height int) string {
 	b.WriteString("\n\n")
 	b.WriteString(content)
 
-	return StyleBase.Copy().Width(width).Height(height).Render(b.String())
+	return styleBase.Copy().Width(width).Height(height).Render(b.String())
 }
 
 func (m Model) renderEndpoint(width int) string {
@@ -121,7 +121,7 @@ func (m Model) renderEndpoint(width int) string {
 		if i == m.methodIndex {
 			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("▶ " + method)
 		} else {
-			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("  " + method)
+			methodLine += styleMuted.Render("  " + method)
 		}
 		if i < len(methods)-1 {
 			methodLine += " "
@@ -130,9 +130,9 @@ func (m Model) renderEndpoint(width int) string {
 
 	b.WriteString(fmt.Sprintf(
 		"\n%s\n  %s\n%s\n  %s",
-		lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("URL"),
+		styleMuted.Render("URL"),
 		m.urlInput.View(),
-		lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("Method"),
+		styleMuted.Render("Method"),
 		methodLine,
 	))
 
@@ -165,7 +165,7 @@ func (m Model) renderPayload(width int) string {
 	b.WriteString("\n")
 
 	if len(m.headers) == 0 {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("  No headers configured."))
+		b.WriteString(styleMuted.Render("  No headers configured."))
 	} else {
 		for i, header := range m.headers {
 			key := header.Key.View()
@@ -231,13 +231,13 @@ func (m Model) renderStatusBar(width int) string {
 	}
 
 	if mode == "" {
-		return StyleStatusBar.Width(width).Render(hints)
+		return styleStatusBar.Width(width).Render(hints)
 	}
 
-	modeStyled := StyleStatusMode.Render(" " + mode + " ")
-	hintsStyled := lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(hints)
+	modeStyled := styleStatusMode.Render(" " + mode + " ")
+	hintsStyled := styleMuted.Render(hints)
 	line := modeStyled + " " + hintsStyled
-	return StyleStatusBar.Width(width).Render(line)
+	return styleStatusBar.Width(width).Render(line)
 }
 
 func visibleWindow(total, selected, height int) int {
@@ -263,19 +263,19 @@ func (m Model) renderResultList(width, height int, identity string, emptyRunning
 
 	remaining := height - 1
 	if metrics := m.metricsString(); metrics != "" {
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Width(width).Render(metrics))
+		b.WriteString(styleMuted.Width(width).Render(metrics))
 		b.WriteString("\n")
 		remaining--
 	}
 
 	if remaining <= 0 {
-		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+		return styleBase.Copy().Width(width).Height(height).Render(b.String())
 	}
 
 	if len(m.results) == 0 {
 		msg := m.renderEmptyState(emptyRunning)
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render(msg))
-		return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+		b.WriteString(styleMuted.Render(msg))
+		return styleBase.Copy().Width(width).Height(height).Render(b.String())
 	}
 
 	start := visibleWindow(len(m.results), m.selected, remaining)
@@ -287,7 +287,7 @@ func (m Model) renderResultList(width, height int, identity string, emptyRunning
 	}
 	b.WriteString(strings.Join(rows, "\n"))
 
-	return lipgloss.NewStyle().Width(width).Height(height).Render(b.String())
+	return styleBase.Copy().Width(width).Height(height).Render(b.String())
 }
 
 func (m Model) renderTimeline(width int, height int) string {
@@ -351,7 +351,7 @@ func (m Model) renderLogs(width int, height int) string {
 
 func (m Model) renderInspect(width int, height int) string {
 	if len(m.results) == 0 || m.selected < 0 || m.selected >= len(m.results) {
-		return StyleBase.Copy().Width(width).Height(height).Render(lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("No result selected."))
+		return styleBase.Copy().Width(width).Height(height).Render(styleMuted.Render("No result selected."))
 	}
 
 	result := m.results[m.selected]
@@ -364,10 +364,9 @@ func (m Model) renderInspect(width int, height int) string {
 		reqURL = m.urlInput.Value()
 	}
 
-	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	errorText := lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
 	sectionLine := func(label string) string {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted)).Render("-- " + label + " --")
+		return styleMuted.Render("-- " + label + " --")
 	}
 
 	identity := identityCell(fmt.Sprintf("Inspector - Result #%d", m.selected+1), false)
@@ -386,7 +385,7 @@ func (m Model) renderInspect(width int, height int) string {
 	lines = append(lines, "", sectionLine("HEADERS"))
 
 	if len(result.ResponseHeaders) == 0 {
-		lines = append(lines, muted.Render("No headers captured."))
+		lines = append(lines, styleMuted.Render("No headers captured."))
 	} else {
 		keys := make([]string, 0, len(result.ResponseHeaders))
 		for key := range result.ResponseHeaders {
@@ -401,20 +400,20 @@ func (m Model) renderInspect(width int, height int) string {
 	lines = append(lines, "", sectionLine("BODY"))
 	body := result.ResponseBody
 	if body == "" {
-		body = muted.Render("No body captured.")
+		body = styleMuted.Render("No body captured.")
 	}
 	bodyLines := strings.Split(body, "\n")
 	for i, bline := range bodyLines {
 		if len(lines) >= height-2 {
 			if i < len(bodyLines)-1 {
-				lines = append(lines, muted.Render("... (truncated)"))
+				lines = append(lines, styleMuted.Render("... (truncated)"))
 			}
 			break
 		}
 		lines = append(lines, truncate(bline, width-4))
 	}
 
-	return StyleBase.Copy().Width(width).Height(height).Render(strings.Join(lines, "\n"))
+	return styleBase.Copy().Width(width).Height(height).Render(strings.Join(lines, "\n"))
 }
 
 func resultStatus(result model.Result) string {


### PR DESCRIPTION
- Remove capped field from model (written but never read in production)
- Unexport 5 style variables (StyleBase -> styleBase, etc.) - only used within the tui package
- Consolidate ~11 inline lipgloss.NewStyle().Foreground(colorMuted) into a single package-level styleMuted variable
- Replace bare lipgloss.NewStyle() in renderResultList with styleBase.Copy() for consistency with other render functions
- Add tmp/ to .gitignore (local audit artifact directory)

References: #93