### PR TITLE
v0.8.5: Command Surface Unification

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -23,6 +23,9 @@ const (
 	bodyFocus        = -1
 	defaultBodyWidth = 48
 	maxTUIBodyBytes  = 1 << 20
+
+	endpointMethod = 0
+	endpointURL    = 1
 )
 
 type mode int
@@ -62,9 +65,10 @@ type Model struct {
 	dialog dialog
 	view   view
 
-	methodIndex int
-	urlInput    textinput.Model
-	ccInput     textinput.Model
+	methodIndex    int
+	endpointField  int
+	urlInput       textinput.Model
+	ccInput        textinput.Model
 	bodyInput   textarea.Model
 
 	headers        []headerRow
@@ -122,8 +126,9 @@ func NewModel() Model {
 		mode:        modeObserve,
 		dialog:      dialogNone,
 		view:        viewTimeline,
-		methodIndex: 0,
-		urlInput:    url,
+		methodIndex:    0,
+		endpointField:  endpointURL,
+		urlInput:       url,
 		ccInput:     cc,
 		bodyInput:   body,
 		status:      "SYSTEM READY",
@@ -241,9 +246,44 @@ func (m Model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleEndpointKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc", "enter":
+	case "esc":
 		m.dialog = dialogNone
 		m.urlInput.Blur()
+		return m, nil
+	case "tab":
+		m.endpointField = (m.endpointField + 1) % 2
+		if m.endpointField == endpointURL {
+			m.urlInput.Focus()
+		} else {
+			m.urlInput.Blur()
+		}
+		return m, nil
+	case "shift+tab":
+		m.endpointField = (m.endpointField + 1) % 2
+		if m.endpointField == endpointURL {
+			m.urlInput.Focus()
+		} else {
+			m.urlInput.Blur()
+		}
+		return m, nil
+	case "left", "h":
+		if m.endpointField == endpointMethod && m.methodIndex > 0 {
+			m.methodIndex--
+		}
+		if m.endpointField != endpointMethod {
+			break
+		}
+		return m, nil
+	case "right", "l":
+		if m.endpointField == endpointMethod {
+			methods := runconfig.AllowedMethods()
+			if m.methodIndex < len(methods)-1 {
+				m.methodIndex++
+			}
+		}
+		if m.endpointField != endpointMethod {
+			break
+		}
 		return m, nil
 	case "ctrl+r":
 		return m.startRun()
@@ -257,7 +297,7 @@ func (m Model) handleEndpointKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleCCKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc", "enter":
+	case "esc":
 		m.dialog = dialogNone
 		m.ccInput.Blur()
 		return m, nil
@@ -429,6 +469,7 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "e":
 		m.dialog = dialogEndpoint
+		m.endpointField = endpointURL
 		m.urlInput.Focus()
 		return m, nil
 	case "c":

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/divijg19/Pulse/internal/model"
+	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
 func TestMethodSelection(t *testing.T) {
@@ -664,27 +665,136 @@ func TestCCDialog_ArrowAdjustDown(t *testing.T) {
 	}
 }
 
-func TestEndpointDialog_EnterCloses(t *testing.T) {
+func TestEndpointDialog_EscCloses(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.urlInput.Focus()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("esc should close endpoint dialog")
+	}
+}
+
+func TestEndpointDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogEndpoint
 	m.urlInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(Model)
-	if m.dialog != dialogNone {
-		t.Fatal("enter should close endpoint dialog")
+	if m.dialog != dialogEndpoint {
+		t.Fatal("enter should NOT close endpoint dialog (esc-only)")
 	}
 }
 
-func TestCCDialog_EnterCloses(t *testing.T) {
+func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.endpointField = endpointMethod
+
+	methods := runconfig.AllowedMethods()
+
+	// Start at index 0
+	if m.methodIndex != 0 {
+		t.Fatalf("methodIndex should start at 0, got %d", m.methodIndex)
+	}
+
+	// Right arrow increments
+	updated, _ := m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(Model)
+	if m.methodIndex != 1 {
+		t.Errorf("after right, methodIndex = %d, want 1", m.methodIndex)
+	}
+
+	// Left arrow decrements
+	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(Model)
+	if m.methodIndex != 0 {
+		t.Errorf("after left, methodIndex = %d, want 0", m.methodIndex)
+	}
+
+	// Left at min does not go below 0
+	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(Model)
+	if m.methodIndex != 0 {
+		t.Errorf("left at min should stay 0, got %d", m.methodIndex)
+	}
+
+	// Right at max does not exceed
+	m.methodIndex = len(methods) - 1
+	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(Model)
+	if m.methodIndex != len(methods)-1 {
+		t.Errorf("right at max should stay %d, got %d", len(methods)-1, m.methodIndex)
+	}
+}
+
+func TestEndpointDialog_TabSwitchesField(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.endpointField = endpointURL
+	m.urlInput.Focus()
+
+	// Tab should switch to method
+	updated, _ := m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.endpointField != endpointMethod {
+		t.Fatal("tab should switch to method field")
+	}
+
+	// Tab again back to URL
+	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.endpointField != endpointURL {
+		t.Fatal("second tab should switch back to URL field")
+	}
+}
+
+func TestEndpointDialog_LeftRightOnUrlDoesNotChangeMethod(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogEndpoint
+	m.endpointField = endpointURL
+	m.urlInput.Focus()
+
+	initialMethod := m.methodIndex
+
+	// Left/right on URL should not change method
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	m = updated.(Model)
+	if m.methodIndex != initialMethod {
+		t.Fatal("left arrow on URL should not change method")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(Model)
+	if m.methodIndex != initialMethod {
+		t.Fatal("right arrow on URL should not change method")
+	}
+}
+
+func TestCCDialog_EscCloses(t *testing.T) {
+	m := NewModel()
+	m.dialog = dialogConcurrency
+	m.ccInput.Focus()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.dialog != dialogNone {
+		t.Fatal("esc should close concurrency dialog")
+	}
+}
+
+func TestCCDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogConcurrency
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(Model)
-	if m.dialog != dialogNone {
-		t.Fatal("enter should close concurrency dialog")
+	if m.dialog != dialogConcurrency {
+		t.Fatal("enter should NOT close concurrency dialog (esc-only)")
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -97,10 +97,22 @@ func (m Model) renderReady(width int, height int) string {
 	url := m.urlInput.Value()
 	cc := m.concurrency()
 
+	payloadParts := []string{}
+	if len(m.headers) > 0 {
+		payloadParts = append(payloadParts, fmt.Sprintf("%d header(s)", len(m.headers)))
+	}
+	if m.bodyInput.Value() != "" {
+		payloadParts = append(payloadParts, "body present")
+	}
+	payloadState := "Empty"
+	if len(payloadParts) > 0 {
+		payloadState = strings.Join(payloadParts, ", ")
+	}
+
 	identity := identityCell("OBSERVE", false)
 
-	content := fmt.Sprintf("Press Ctrl+R to run\n\n%s %s\n\nCC %d\n\ne Endpoint    c Concurrency    p Payload",
-		method, url, cc)
+	content := fmt.Sprintf("%s    %s\n\nCC %d\n\nBody  %s",
+		method, url, cc, payloadState)
 
 	var b strings.Builder
 	b.WriteString(identity)
@@ -118,22 +130,30 @@ func (m Model) renderEndpoint(width int) string {
 	methods := runconfig.AllowedMethods()
 	var methodLine string
 	for i, method := range methods {
-		if i == m.methodIndex {
-			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("▶ " + method)
+		sel := i == m.methodIndex
+		focus := m.endpointField == endpointMethod
+		if sel && focus {
+			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Background(lipgloss.Color(colorDark)).Render(" " + method + " ")
+		} else if sel {
+			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render(" " + method + " ")
 		} else {
-			methodLine += styleMuted.Render("  " + method)
+			methodLine += styleMuted.Render(" " + method + " ")
 		}
-		if i < len(methods)-1 {
-			methodLine += " "
-		}
+	}
+
+	methodLabel := "Method"
+	if m.endpointField == endpointMethod {
+		methodLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("Method")
+	} else {
+		methodLabel = styleMuted.Render("Method")
 	}
 
 	b.WriteString(fmt.Sprintf(
 		"\n%s\n  %s\n%s\n  %s",
+		methodLabel,
+		methodLine,
 		styleMuted.Render("URL"),
 		m.urlInput.View(),
-		styleMuted.Render("Method"),
-		methodLine,
 	))
 
 	return b.String()
@@ -198,46 +218,30 @@ func (m Model) renderPayload(width int) string {
 }
 
 func (m Model) renderStatusBar(width int) string {
-	var mode, hints string
+	var hints string
 
 	switch {
 	case m.dialog == dialogConfirmQuit:
-		mode = ""
 		hints = "Enter/q/Ctrl+C to quit, any key cancels"
 	case m.dialog == dialogEndpoint:
-		mode = "ENDPOINT"
-		hints = "• Esc • Enter"
+		hints = "Tab Next Field  ← → Method  Esc Back"
 	case m.dialog == dialogConcurrency:
-		mode = "CONCURRENCY"
-		hints = "• ↑↓ • Enter • Esc"
+		hints = "↑ ↓ Adjust  Esc Back"
 	case m.dialog == dialogPayload:
-		mode = "PAYLOAD"
-		hints = "• Tab • ↑↓ • ←→ • Ctrl+N • Ctrl+D • Esc"
+		hints = "Tab Next  Ctrl+N Header  Ctrl+D Delete  Esc Back"
 	case m.mode == modeInspect:
-		mode = "INSPECTING"
-		hints = "• ↑↓ • Esc • q"
+		hints = "↑ ↓ Select  Esc Back  q Quit"
 	case m.running && len(m.results) == 0:
-		mode = "RUNNING"
-		hints = "• Ctrl+X • q"
+		hints = "Ctrl+X Cancel"
 	case m.running:
-		mode = "RUNNING"
-		hints = "• ↑↓ • Enter inspect • [ ] views • Ctrl+X • q"
+		hints = "↑ ↓ Select  Enter Inspect  [ ] Views  Ctrl+X Cancel"
 	case !m.running && len(m.results) == 0:
-		mode = "OBSERVE"
-		hints = "• e • c • p • Ctrl+R • q"
+		hints = "e Endpoint  c Concurrency  p Payload  Ctrl+R Run  q Quit"
 	default:
-		mode = "OBSERVE"
-		hints = "• ↑↓ • Enter inspect • [ ] views • e • c • p • Ctrl+R • q"
+		hints = "↑ ↓ Select  Enter Inspect  [ ] Views  e Endpoint  c Concurrency  p Payload  Ctrl+R Run  q Quit"
 	}
 
-	if mode == "" {
-		return styleStatusBar.Width(width).Render(hints)
-	}
-
-	modeStyled := styleStatusMode.Render(" " + mode + " ")
-	hintsStyled := styleMuted.Render(hints)
-	line := modeStyled + " " + hintsStyled
-	return styleStatusBar.Width(width).Render(line)
+	return styleStatusBar.Width(width).Render(hints)
 }
 
 func visibleWindow(total, selected, height int) int {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -21,8 +21,8 @@ func TestView_Idle(t *testing.T) {
 	if !contains(t, out, "GET") {
 		t.Fatal("View should contain method")
 	}
-	if !contains(t, out, "Ctrl+R to run") {
-		t.Fatal("View should contain 'Ctrl+R to run' in Ready surface")
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("View should contain OBSERVE identity in Ready surface")
 	}
 }
 
@@ -38,14 +38,14 @@ func TestView_Running(t *testing.T) {
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
 	out := m.View()
-	if !contains(t, out, "RUNNING") {
-		t.Fatal("running view should show running indicator")
-	}
 	if !contains(t, out, "r/s") {
 		t.Fatal("running view should show requests per second")
 	}
 	if !contains(t, out, "Timeline") {
 		t.Fatal("running view should show Timeline identity")
+	}
+	if !contains(t, out, "Ctrl+X") {
+		t.Fatal("running view should show cancel hint in footer")
 	}
 }
 
@@ -63,17 +63,11 @@ func TestRenderReady(t *testing.T) {
 	if !contains(t, out, "CC 10") {
 		t.Fatal("Ready should show concurrency")
 	}
-	if !contains(t, out, "Ctrl+R to run") {
-		t.Fatal("Ready should show run CTA")
+	if !contains(t, out, "Body") {
+		t.Fatal("Ready should show payload state")
 	}
-	if !contains(t, out, "Endpoint") {
-		t.Fatal("Ready should show endpoint action link")
-	}
-	if !contains(t, out, "Concurrency") {
-		t.Fatal("Ready should show concurrency action link")
-	}
-	if !contains(t, out, "Payload") {
-		t.Fatal("Ready should show payload action link")
+	if !contains(t, out, "Empty") {
+		t.Fatal("Ready should show payload as empty")
 	}
 }
 
@@ -83,13 +77,13 @@ func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 	m.height = 30
 
 	out := m.View()
-	if !contains(t, out, "Ctrl+R to run") {
+	if !contains(t, out, "OBSERVE") {
 		t.Fatal("first launch should show Ready surface")
 	}
 
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out = m.View()
-	if contains(t, out, "Ready") {
+	if contains(t, out, "OBSERVE") {
 		t.Fatal("after results exist, Ready should not appear")
 	}
 }
@@ -249,10 +243,7 @@ func TestRenderStatusBar_Normal(t *testing.T) {
 	m.width = 100
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "OBSERVE") {
-		t.Fatal("status bar should show 'OBSERVE' mode")
-	}
-	if !contains(t, out, "↑↓") {
+	if !contains(t, out, "↑ ↓ Select") {
 		t.Fatal("post-run status bar should show scroll hint")
 	}
 }
@@ -261,8 +252,14 @@ func TestRenderStatusBar_Ready(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "OBSERVE") {
-		t.Fatal("ready status bar should show 'OBSERVE' mode")
+	if !contains(t, out, "Endpoint") {
+		t.Fatal("ready status bar should show Endpoint")
+	}
+	if !contains(t, out, "Concurrency") {
+		t.Fatal("ready status bar should show Concurrency")
+	}
+	if !contains(t, out, "Payload") {
+		t.Fatal("ready status bar should show Payload")
 	}
 	if contains(t, out, "↑↓") {
 		t.Fatal("ready status bar should not advertise ↑↓ (inert)")
@@ -276,8 +273,8 @@ func TestRenderStatusBar_Ready(t *testing.T) {
 	if !contains(t, out, "Ctrl+R") {
 		t.Fatal("ready status bar should show Ctrl+R")
 	}
-	if !contains(t, out, "q") {
-		t.Fatal("ready status bar should show q (quit)")
+	if !contains(t, out, "Quit") {
+		t.Fatal("ready status bar should show Quit")
 	}
 }
 
@@ -286,8 +283,8 @@ func TestRenderStatusBar_RunningEmpty(t *testing.T) {
 	m.width = 100
 	m.running = true
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "RUNNING") {
-		t.Fatal("status bar should show 'RUNNING' mode")
+	if !contains(t, out, "Ctrl+X") {
+		t.Fatal("running empty status bar should show Ctrl+X")
 	}
 	if contains(t, out, "↑↓") {
 		t.Fatal("running empty should not advertise ↑↓ (inert)")
@@ -303,13 +300,10 @@ func TestRenderStatusBar_RunningWithResults(t *testing.T) {
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "RUNNING") {
-		t.Fatal("status bar should show 'RUNNING' mode")
+	if !contains(t, out, "Enter Inspect") {
+		t.Fatal("running status bar should show Enter Inspect")
 	}
-	if !contains(t, out, "Enter inspect") {
-		t.Fatal("running status bar should show Enter inspect")
-	}
-	if !contains(t, out, "[ ]") {
+	if !contains(t, out, "[ ] Views") {
 		t.Fatal("running status bar should show view switching")
 	}
 }
@@ -319,11 +313,11 @@ func TestRenderStatusBar_EndpointDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogEndpoint
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "ENDPOINT") {
-		t.Fatal("status bar should show 'ENDPOINT' mode")
+	if !contains(t, out, "Esc Back") {
+		t.Fatal("endpoint status bar should show Esc Back")
 	}
-	if !contains(t, out, "Enter") {
-		t.Fatal("endpoint status bar should show Enter")
+	if !contains(t, out, "Tab Next Field") {
+		t.Fatal("endpoint status bar should show Tab Next Field")
 	}
 }
 
@@ -332,11 +326,11 @@ func TestRenderStatusBar_CCDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogConcurrency
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "CONCURRENCY") {
-		t.Fatal("status bar should show 'CONCURRENCY' mode")
+	if !contains(t, out, "Esc Back") {
+		t.Fatal("concurrency status bar should show Esc Back")
 	}
-	if !contains(t, out, "Enter") {
-		t.Fatal("concurrency status bar should show Enter")
+	if !contains(t, out, "↑ ↓ Adjust") {
+		t.Fatal("concurrency status bar should show ↑ ↓ Adjust")
 	}
 }
 
@@ -345,8 +339,11 @@ func TestRenderStatusBar_Inspecting(t *testing.T) {
 	m.width = 100
 	m.mode = modeInspect
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "INSPECTING") {
-		t.Fatal("status bar should show 'INSPECTING' mode")
+	if !contains(t, out, "Esc Back") {
+		t.Fatal("inspect status bar should show Esc Back")
+	}
+	if !contains(t, out, "q Quit") {
+		t.Fatal("inspect status bar should show q Quit")
 	}
 }
 
@@ -1083,17 +1080,17 @@ func TestRenderStatusBar_PayloadDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogPayload
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "PAYLOAD") {
-		t.Fatal("status bar should show 'PAYLOAD' mode")
-	}
-	if !contains(t, out, "Tab") {
-		t.Fatal("payload status bar should show Tab hint")
+	if !contains(t, out, "Tab Next") {
+		t.Fatal("payload status bar should show Tab Next hint")
 	}
 	if !contains(t, out, "Ctrl+N") {
 		t.Fatal("payload status bar should show Ctrl+N hint")
 	}
 	if !contains(t, out, "Ctrl+D") {
 		t.Fatal("payload status bar should show Ctrl+D hint")
+	}
+	if !contains(t, out, "Esc Back") {
+		t.Fatal("payload status bar should show Esc Back hint")
 	}
 }
 


### PR DESCRIPTION
- Footer: single authoritative command surface with full-word labels, no mode badges, no bullets, no abbreviations across all 8 states
- Endpoint: Method + URL as equal peer fields with Tab switching
- Method selection: ←→ cycles through methods when method field focused
- Esc-only dismiss: Endpoint, Concurrency, and Payload dialogs close only on Esc (Enter removed from Endpoint and Concurrency)
- Body = State: no commands render in content area; shows only Method, URL, CC, and payload state
- endpointField tracks focused field in endpoint dialog
- Tests: method switching, Esc-only dismiss, updated status bar and ready body assertions