### PR TITLE
v0.8.6: Workspace Layout Foundation

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -65,11 +65,11 @@ type Model struct {
 	dialog dialog
 	view   view
 
-	methodIndex    int
-	endpointField  int
-	urlInput       textinput.Model
-	ccInput        textinput.Model
-	bodyInput   textarea.Model
+	methodIndex   int
+	endpointField int
+	urlInput      textinput.Model
+	ccInput       textinput.Model
+	bodyInput     textarea.Model
 
 	headers        []headerRow
 	selectedHead   int
@@ -123,15 +123,15 @@ func NewModel() Model {
 	body.SetWidth(defaultBodyWidth)
 
 	return Model{
-		mode:        modeObserve,
-		dialog:      dialogNone,
-		view:        viewTimeline,
-		methodIndex:    0,
-		endpointField:  endpointURL,
-		urlInput:       url,
-		ccInput:     cc,
-		bodyInput:   body,
-		status:      "SYSTEM READY",
+		mode:          modeObserve,
+		dialog:        dialogNone,
+		view:          viewTimeline,
+		methodIndex:   0,
+		endpointField: endpointURL,
+		urlInput:      url,
+		ccInput:       cc,
+		bodyInput:     body,
+		status:        "SYSTEM READY",
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -11,43 +11,65 @@ import (
 	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
+type Region struct {
+	Width  int
+	Height int
+}
+
+type ShellLayout struct {
+	Context   Region
+	Workspace Region
+	Command   Region
+}
+
+func computeShellLayout(totalWidth, totalHeight int) ShellLayout {
+	width := max(72, totalWidth)
+	bodyHeight := max(1, totalHeight-5)
+	return ShellLayout{
+		Context:   Region{Width: width, Height: 1},
+		Workspace: Region{Width: width, Height: bodyHeight},
+		Command:   Region{Width: width, Height: 1},
+	}
+}
+
 func (m Model) View() string {
 	if m.width == 0 {
 		return "Pulse is starting..."
 	}
 
-	width := max(72, m.width)
-	bodyHeight := max(1, m.height-5)
+	layout := computeShellLayout(m.width, m.height)
 
 	var sb strings.Builder
-	sb.WriteString(m.renderTopBar(width))
+	sb.WriteString(m.renderTopBar(layout.Context.Width))
 	sb.WriteString("\n")
-	sb.WriteString(styleSeparator.Render(strings.Repeat("─", width)))
+	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Context.Width)))
 	sb.WriteString("\n")
+	sb.WriteString(m.renderCurrentSurface(layout.Workspace))
+	sb.WriteString("\n")
+	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Command.Width)))
+	sb.WriteString("\n")
+	sb.WriteString(m.renderStatusBar(layout.Command.Width))
 
+	return styleBase.Width(layout.Context.Width).Height(m.height).Render(sb.String())
+}
+
+func (m Model) renderCurrentSurface(region Region) string {
 	switch {
 	case m.dialog == dialogPayload:
-		sb.WriteString(m.renderPayload(width))
+		return m.renderPayload(region)
 	case m.dialog == dialogEndpoint:
-		sb.WriteString(m.renderEndpoint(width))
+		return m.renderEndpoint(region)
 	case m.dialog == dialogConcurrency:
-		sb.WriteString(m.renderConcurrency(width))
+		return m.renderConcurrency(region)
 	case m.mode == modeInspect:
-		sb.WriteString(m.renderInspect(width, bodyHeight))
+		return m.renderInspect(region)
 	case !m.running && len(m.results) == 0:
-		sb.WriteString(m.renderReady(width, bodyHeight))
+		return m.renderReady(region)
 	case m.view == viewTimeline:
-		sb.WriteString(m.renderTimeline(width, bodyHeight))
+		return m.renderTimeline(region)
 	default:
-		sb.WriteString(m.renderLogs(width, bodyHeight))
+		return m.renderLogs(region)
 	}
-
-	sb.WriteString("\n")
-	sb.WriteString(styleSeparator.Render(strings.Repeat("─", width)))
-	sb.WriteString("\n")
-	sb.WriteString(m.renderStatusBar(width))
-
-	return styleBase.Width(width).Height(m.height).Render(sb.String())
 }
 
 func identityCell(label string, subdued bool) string {
@@ -70,6 +92,21 @@ func (m Model) metricsString() string {
 		s.SuccessRate, rps, formatDuration(s.P90), formatDuration(s.P99))
 }
 
+func (m Model) payloadSummary() string {
+	h := len(m.headers)
+	hasBody := m.bodyInput.Value() != ""
+	switch {
+	case h == 0 && !hasBody:
+		return "—"
+	case h > 0 && hasBody:
+		return fmt.Sprintf("%dH+B", h)
+	case h > 0:
+		return fmt.Sprintf("%dH", h)
+	default:
+		return "B"
+	}
+}
+
 func (m Model) renderTopBar(width int) string {
 	method := runconfig.AllowedMethods()[m.methodIndex]
 	url := truncateURL(m.urlInput.Value(), 40)
@@ -77,6 +114,11 @@ func (m Model) renderTopBar(width int) string {
 
 	cc := strings.TrimSpace(m.ccInput.Value())
 	right := "CC " + cc
+
+	ps := m.payloadSummary()
+	if ps != "—" && width >= 100 {
+		right += " · Payload " + ps
+	}
 
 	maxLeft := width - lipgloss.Width(right) - 3
 	if maxLeft < 12 {
@@ -92,37 +134,27 @@ func (m Model) renderTopBar(width int) string {
 	return styleTopBar.Width(width).Render(line)
 }
 
-func (m Model) renderReady(width int, height int) string {
+func (m Model) renderReady(region Region) string {
 	method := runconfig.AllowedMethods()[m.methodIndex]
 	url := m.urlInput.Value()
 	cc := m.concurrency()
 
-	payloadParts := []string{}
-	if len(m.headers) > 0 {
-		payloadParts = append(payloadParts, fmt.Sprintf("%d header(s)", len(m.headers)))
-	}
-	if m.bodyInput.Value() != "" {
-		payloadParts = append(payloadParts, "body present")
-	}
-	payloadState := "Empty"
-	if len(payloadParts) > 0 {
-		payloadState = strings.Join(payloadParts, ", ")
-	}
+	payloadLabel := "Payload " + m.payloadSummary()
 
 	identity := identityCell("OBSERVE", false)
 
-	content := fmt.Sprintf("%s    %s\n\nCC %d\n\nBody  %s",
-		method, url, cc, payloadState)
+	content := fmt.Sprintf("%s    %s\n\nCC %d\n\n%s",
+		method, url, cc, payloadLabel)
 
 	var b strings.Builder
 	b.WriteString(identity)
 	b.WriteString("\n\n")
 	b.WriteString(content)
 
-	return styleBase.Copy().Width(width).Height(height).Render(b.String())
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderEndpoint(width int) string {
+func (m Model) renderEndpoint(region Region) string {
 	var b strings.Builder
 	b.WriteString(identityCell("Endpoint", true))
 	b.WriteString("\n")
@@ -156,10 +188,10 @@ func (m Model) renderEndpoint(width int) string {
 		m.urlInput.View(),
 	))
 
-	return b.String()
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderConcurrency(width int) string {
+func (m Model) renderConcurrency(region Region) string {
 	var b strings.Builder
 	b.WriteString(identityCell("Concurrency", true))
 	b.WriteString("\n\n")
@@ -168,10 +200,11 @@ func (m Model) renderConcurrency(width int) string {
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true).Render(
 		fmt.Sprintf("  %s  (1–%d)", ccText, runconfig.MaxConcurrency),
 	))
-	return b.String()
+
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderPayload(width int) string {
+func (m Model) renderPayload(region Region) string {
 	var b strings.Builder
 	b.WriteString(identityCell("Payload", true))
 	b.WriteString("\n")
@@ -214,7 +247,7 @@ func (m Model) renderPayload(width int) string {
 
 	b.WriteString(m.bodyInput.View())
 
-	return b.String()
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
 func (m Model) renderStatusBar(width int) string {
@@ -222,23 +255,23 @@ func (m Model) renderStatusBar(width int) string {
 
 	switch {
 	case m.dialog == dialogConfirmQuit:
-		hints = "Enter/q/Ctrl+C to quit, any key cancels"
+		hints = "  [Enter]  [q]  [Ctrl+C] to quit  ·  any key cancels"
 	case m.dialog == dialogEndpoint:
-		hints = "Tab Next Field  ← → Method  Esc Back"
+		hints = "  [Tab] Next Field  ·  [←→] Method  ·  [Esc] Back"
 	case m.dialog == dialogConcurrency:
-		hints = "↑ ↓ Adjust  Esc Back"
+		hints = "  [↑↓] Adjust  ·  [Esc] Back"
 	case m.dialog == dialogPayload:
-		hints = "Tab Next  Ctrl+N Header  Ctrl+D Delete  Esc Back"
+		hints = "  [Tab] Next  ·  [Ctrl+N] Header  ·  [Ctrl+D] Delete  ·  [Esc] Back"
 	case m.mode == modeInspect:
-		hints = "↑ ↓ Select  Esc Back  q Quit"
+		hints = "  [↑↓] Select  ·  [Esc] Back  ·  [q] Quit"
 	case m.running && len(m.results) == 0:
-		hints = "Ctrl+X Cancel"
+		hints = "  [Ctrl+X] Cancel"
 	case m.running:
-		hints = "↑ ↓ Select  Enter Inspect  [ ] Views  Ctrl+X Cancel"
+		hints = "  [↑↓] Select  ·  [Enter] Inspect  ·  [Tab] Views  ·  [Ctrl+X] Cancel"
 	case !m.running && len(m.results) == 0:
-		hints = "e Endpoint  c Concurrency  p Payload  Ctrl+R Run  q Quit"
+		hints = "  [e] Endpoint  ·  [c] Concurrency  ·  [p] Payload  ·  [Ctrl+R] Run  ·  [q] Quit"
 	default:
-		hints = "↑ ↓ Select  Enter Inspect  [ ] Views  e Endpoint  c Concurrency  p Payload  Ctrl+R Run  q Quit"
+		hints = "  [↑↓] Select  ·  [Enter] Inspect  ·  [Tab] Views  ·  [e] Endpoint  ·  [c] Concurrency  ·  [p] Payload  ·  [Ctrl+R] Run  ·  [q] Quit"
 	}
 
 	return styleStatusBar.Width(width).Render(hints)
@@ -259,27 +292,27 @@ func visibleWindow(total, selected, height int) int {
 	return start
 }
 
-func (m Model) renderResultList(width, height int, identity string, emptyRunning string, rowFn func(result model.Result, index int, selected bool, width int) string) string {
+func (m Model) renderResultList(region Region, identity string, emptyRunning string, rowFn func(result model.Result, index int, selected bool, width int) string) string {
 	var b strings.Builder
 
 	b.WriteString(identityCell(identity, false))
 	b.WriteString("\n")
 
-	remaining := height - 1
+	remaining := region.Height - 1
 	if metrics := m.metricsString(); metrics != "" {
-		b.WriteString(styleMuted.Width(width).Render(metrics))
+		b.WriteString(styleMuted.Width(region.Width).Render(metrics))
 		b.WriteString("\n")
 		remaining--
 	}
 
 	if remaining <= 0 {
-		return styleBase.Copy().Width(width).Height(height).Render(b.String())
+		return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 	}
 
 	if len(m.results) == 0 {
 		msg := m.renderEmptyState(emptyRunning)
 		b.WriteString(styleMuted.Render(msg))
-		return styleBase.Copy().Width(width).Height(height).Render(b.String())
+		return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 	}
 
 	start := visibleWindow(len(m.results), m.selected, remaining)
@@ -287,15 +320,15 @@ func (m Model) renderResultList(width, height int, identity string, emptyRunning
 	for i := start; i < len(m.results) && len(rows) < remaining; i++ {
 		result := m.results[i]
 		sel := i == m.selected
-		rows = append(rows, rowFn(result, i, sel, width))
+		rows = append(rows, rowFn(result, i, sel, region.Width))
 	}
 	b.WriteString(strings.Join(rows, "\n"))
 
-	return styleBase.Copy().Width(width).Height(height).Render(b.String())
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderTimeline(width int, height int) string {
-	return m.renderResultList(width, height, "Timeline", "⏳  Waiting for results...",
+func (m Model) renderTimeline(region Region) string {
+	return m.renderResultList(region, "Timeline", "⏳  Waiting for results...",
 		func(result model.Result, index int, selected bool, width int) string {
 			return m.renderTimelineRow(index, result, m.summary.MaxLatency, width, selected)
 		})
@@ -332,8 +365,8 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
 }
 
-func (m Model) renderLogs(width int, height int) string {
-	return m.renderResultList(width, height, "Logs", "📭  No results yet...",
+func (m Model) renderLogs(region Region) string {
+	return m.renderResultList(region, "Logs", "📭  No results yet...",
 		func(result model.Result, index int, selected bool, width int) string {
 			status := resultStatus(result)
 			method := result.RequestMethod
@@ -353,9 +386,9 @@ func (m Model) renderLogs(width int, height int) string {
 		})
 }
 
-func (m Model) renderInspect(width int, height int) string {
+func (m Model) renderInspect(region Region) string {
 	if len(m.results) == 0 || m.selected < 0 || m.selected >= len(m.results) {
-		return styleBase.Copy().Width(width).Height(height).Render(styleMuted.Render("No result selected."))
+		return styleBase.Copy().Width(region.Width).Height(region.Height).Render(styleMuted.Render("No result selected."))
 	}
 
 	result := m.results[m.selected]
@@ -378,7 +411,7 @@ func (m Model) renderInspect(width int, height int) string {
 	lines := []string{
 		identity,
 		"",
-		fmt.Sprintf("  %s %s", method, truncate(reqURL, width-12)),
+		fmt.Sprintf("  %s %s", method, truncate(reqURL, region.Width-12)),
 		"",
 		lipgloss.NewStyle().Foreground(lipgloss.Color(statusColor(result.Status))).Render("Status:  " + resultStatus(result)),
 		fmt.Sprintf("Latency: %s", formatDuration(result.Latency)),
@@ -397,7 +430,7 @@ func (m Model) renderInspect(width int, height int) string {
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			lines = append(lines, truncate(fmt.Sprintf("%s: %s", key, result.ResponseHeaders[key]), width-4))
+			lines = append(lines, truncate(fmt.Sprintf("%s: %s", key, result.ResponseHeaders[key]), region.Width-4))
 		}
 	}
 
@@ -408,16 +441,16 @@ func (m Model) renderInspect(width int, height int) string {
 	}
 	bodyLines := strings.Split(body, "\n")
 	for i, bline := range bodyLines {
-		if len(lines) >= height-2 {
+		if len(lines) >= region.Height-2 {
 			if i < len(bodyLines)-1 {
 				lines = append(lines, styleMuted.Render("... (truncated)"))
 			}
 			break
 		}
-		lines = append(lines, truncate(bline, width-4))
+		lines = append(lines, truncate(bline, region.Width-4))
 	}
 
-	return styleBase.Copy().Width(width).Height(height).Render(strings.Join(lines, "\n"))
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(strings.Join(lines, "\n"))
 }
 
 func resultStatus(result model.Result) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -53,7 +53,7 @@ func TestRenderReady(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.height = 30
-	out := m.renderReady(100, 26)
+	out := m.renderReady(Region{Width: 100, Height: 26})
 	if !contains(t, out, "OBSERVE") {
 		t.Fatal("Ready should show identity")
 	}
@@ -63,11 +63,11 @@ func TestRenderReady(t *testing.T) {
 	if !contains(t, out, "CC 10") {
 		t.Fatal("Ready should show concurrency")
 	}
-	if !contains(t, out, "Body") {
+	if !contains(t, out, "Payload") {
 		t.Fatal("Ready should show payload state")
 	}
-	if !contains(t, out, "Empty") {
-		t.Fatal("Ready should show payload as empty")
+	if !contains(t, out, "—") {
+		t.Fatal("Ready should show payload as empty (—)")
 	}
 }
 
@@ -97,6 +97,23 @@ func TestRenderTopBar_ShowsMethodAndURL(t *testing.T) {
 	}
 	if !contains(t, out, "httpbin") {
 		t.Fatal("top bar should contain URL")
+	}
+}
+
+func TestRenderTopBar_ShowsPayloadSummary(t *testing.T) {
+	m := NewModel()
+	m.width = 120
+	m.headers = append(m.headers, newHeaderRow())
+	m.headers[0].Key.SetValue("Content-Type")
+	m.headers[0].Value.SetValue("application/json")
+	m.bodyInput.SetValue(`{"key": "value"}`)
+
+	out := m.renderTopBar(120)
+	if !contains(t, out, "Payload") {
+		t.Fatal("top bar should show payload summary when width permits")
+	}
+	if !contains(t, out, "1H+B") {
+		t.Fatal("top bar should show payload summary with header count and body indicator")
 	}
 }
 
@@ -243,8 +260,11 @@ func TestRenderStatusBar_Normal(t *testing.T) {
 	m.width = 100
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "↑ ↓ Select") {
+	if !contains(t, out, "[↑↓] Select") {
 		t.Fatal("post-run status bar should show scroll hint")
+	}
+	if !contains(t, out, "[Tab] Views") {
+		t.Fatal("post-run status bar should show view switch command")
 	}
 }
 
@@ -252,29 +272,29 @@ func TestRenderStatusBar_Ready(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Endpoint") {
-		t.Fatal("ready status bar should show Endpoint")
+	if !contains(t, out, "[e] Endpoint") {
+		t.Fatal("ready status bar should show [e] Endpoint")
 	}
-	if !contains(t, out, "Concurrency") {
-		t.Fatal("ready status bar should show Concurrency")
+	if !contains(t, out, "[c] Concurrency") {
+		t.Fatal("ready status bar should show [c] Concurrency")
 	}
-	if !contains(t, out, "Payload") {
-		t.Fatal("ready status bar should show Payload")
+	if !contains(t, out, "[p] Payload") {
+		t.Fatal("ready status bar should show [p] Payload")
 	}
-	if contains(t, out, "↑↓") {
-		t.Fatal("ready status bar should not advertise ↑↓ (inert)")
+	if contains(t, out, "[↑↓]") {
+		t.Fatal("ready status bar should not advertise [↑↓] (inert)")
 	}
-	if contains(t, out, "Enter") {
-		t.Fatal("ready status bar should not advertise Enter (inert)")
+	if contains(t, out, "[Enter]") {
+		t.Fatal("ready status bar should not advertise [Enter] (inert)")
 	}
-	if contains(t, out, "[ ]") {
-		t.Fatal("ready status bar should not advertise view switching (inert)")
+	if contains(t, out, "[Tab]") {
+		t.Fatal("ready status bar should not advertise [Tab] (inert)")
 	}
-	if !contains(t, out, "Ctrl+R") {
-		t.Fatal("ready status bar should show Ctrl+R")
+	if !contains(t, out, "[Ctrl+R]") {
+		t.Fatal("ready status bar should show [Ctrl+R]")
 	}
-	if !contains(t, out, "Quit") {
-		t.Fatal("ready status bar should show Quit")
+	if !contains(t, out, "[q] Quit") {
+		t.Fatal("ready status bar should show [q] Quit")
 	}
 }
 
@@ -300,11 +320,14 @@ func TestRenderStatusBar_RunningWithResults(t *testing.T) {
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Enter Inspect") {
-		t.Fatal("running status bar should show Enter Inspect")
+	if !contains(t, out, "[Enter] Inspect") {
+		t.Fatal("running status bar should show [Enter] Inspect")
 	}
-	if !contains(t, out, "[ ] Views") {
-		t.Fatal("running status bar should show view switching")
+	if !contains(t, out, "[Tab] Views") {
+		t.Fatal("running status bar should show [Tab] Views")
+	}
+	if !contains(t, out, "[Ctrl+X]") {
+		t.Fatal("running status bar should show [Ctrl+X] Cancel")
 	}
 }
 
@@ -313,11 +336,14 @@ func TestRenderStatusBar_EndpointDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogEndpoint
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Esc Back") {
-		t.Fatal("endpoint status bar should show Esc Back")
+	if !contains(t, out, "[Esc] Back") {
+		t.Fatal("endpoint status bar should show [Esc] Back")
 	}
-	if !contains(t, out, "Tab Next Field") {
-		t.Fatal("endpoint status bar should show Tab Next Field")
+	if !contains(t, out, "[Tab] Next Field") {
+		t.Fatal("endpoint status bar should show [Tab] Next Field")
+	}
+	if !contains(t, out, "[←→] Method") {
+		t.Fatal("endpoint status bar should show [←→] Method")
 	}
 }
 
@@ -326,11 +352,11 @@ func TestRenderStatusBar_CCDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogConcurrency
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Esc Back") {
-		t.Fatal("concurrency status bar should show Esc Back")
+	if !contains(t, out, "[Esc] Back") {
+		t.Fatal("concurrency status bar should show [Esc] Back")
 	}
-	if !contains(t, out, "↑ ↓ Adjust") {
-		t.Fatal("concurrency status bar should show ↑ ↓ Adjust")
+	if !contains(t, out, "[↑↓] Adjust") {
+		t.Fatal("concurrency status bar should show [↑↓] Adjust")
 	}
 }
 
@@ -339,11 +365,11 @@ func TestRenderStatusBar_Inspecting(t *testing.T) {
 	m.width = 100
 	m.mode = modeInspect
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Esc Back") {
-		t.Fatal("inspect status bar should show Esc Back")
+	if !contains(t, out, "[Esc] Back") {
+		t.Fatal("inspect status bar should show [Esc] Back")
 	}
-	if !contains(t, out, "q Quit") {
-		t.Fatal("inspect status bar should show q Quit")
+	if !contains(t, out, "[q] Quit") {
+		t.Fatal("inspect status bar should show [q] Quit")
 	}
 }
 
@@ -369,7 +395,7 @@ func TestRenderTimeline_Identity(t *testing.T) {
 	m.summary.MaxLatency = 100 * time.Millisecond
 	m.selected = 0
 
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("timeline should show identity header")
 	}
@@ -378,7 +404,7 @@ func TestRenderTimeline_Identity(t *testing.T) {
 func TestRenderTimeline_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("empty timeline should show Timeline identity")
 	}
@@ -397,7 +423,7 @@ func TestRenderTimeline_Rows(t *testing.T) {
 	m.summary.MaxLatency = 100 * time.Millisecond
 	m.selected = 0
 
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "200") {
 		t.Fatal("timeline should show status code 200")
 	}
@@ -418,7 +444,7 @@ func TestRenderLogs_Identity(t *testing.T) {
 	m.summary.MaxLatency = 100 * time.Millisecond
 	m.selected = 0
 
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("logs should show identity header")
 	}
@@ -427,7 +453,7 @@ func TestRenderLogs_Identity(t *testing.T) {
 func TestRenderLogs_Empty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("empty logs should show Logs identity")
 	}
@@ -447,7 +473,7 @@ func TestRenderLogs_Rows(t *testing.T) {
 	m.summary.MaxLatency = 100 * time.Millisecond
 	m.selected = 0
 
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "GET") {
 		t.Fatal("logs should show method 'GET'")
 	}
@@ -473,7 +499,7 @@ func TestRenderInspect_Identity(t *testing.T) {
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "Inspector") {
 		t.Fatal("inspector should show identity header")
 	}
@@ -485,7 +511,7 @@ func TestRenderInspect_Identity(t *testing.T) {
 func TestRenderInspect_NoSelection(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "No result selected.") {
 		t.Fatal("inspector with no selection should show 'No result selected.'")
 	}
@@ -506,7 +532,7 @@ func TestRenderInspect_WithResult(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "200") {
 		t.Fatal("inspector should show status")
 	}
@@ -533,7 +559,7 @@ func TestRenderInspect_NoMetrics(t *testing.T) {
 	m.summary.SuccessRate = 90
 	m.elapsed = 5 * time.Second
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if contains(t, out, "% ok") {
 		t.Fatal("inspector should NOT show aggregate metrics")
 	}
@@ -554,7 +580,7 @@ func TestRenderInspect_WithError(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "connection refused") {
 		t.Fatal("inspector should show error message")
 	}
@@ -574,7 +600,7 @@ func TestRenderInspect_NoHeaders(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "No headers captured.") {
 		t.Fatal("inspector should show 'No headers captured.' when no response headers")
 	}
@@ -594,7 +620,7 @@ func TestRenderInspect_NoBody(t *testing.T) {
 		},
 	}
 
-	out := m.renderInspect(40, 20)
+	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "No body captured.") {
 		t.Fatal("inspector should show 'No body captured.' when no response body")
 	}
@@ -685,7 +711,7 @@ func TestRenderTimeline_RunningEmpty(t *testing.T) {
 	m.running = true
 	m.status = "RUNNING"
 
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("running empty timeline should show Timeline identity")
 	}
@@ -700,7 +726,7 @@ func TestRenderTimeline_IdleNoURL(t *testing.T) {
 	m.running = false
 	m.urlInput.SetValue("")
 
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("idle empty timeline should show Timeline identity")
 	}
@@ -715,7 +741,7 @@ func TestRenderTimeline_IdleWithURL(t *testing.T) {
 	m.running = false
 	m.urlInput.SetValue("https://example.com/api")
 
-	out := m.renderTimeline(94, 20)
+	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("idle empty timeline should show Timeline identity")
 	}
@@ -730,7 +756,7 @@ func TestRenderLogs_RunningEmpty(t *testing.T) {
 	m.running = true
 	m.status = "RUNNING"
 
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("running empty logs should show Logs identity")
 	}
@@ -745,7 +771,7 @@ func TestRenderLogs_IdleNoURL(t *testing.T) {
 	m.running = false
 	m.urlInput.SetValue("")
 
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("idle empty logs should show Logs identity")
 	}
@@ -760,7 +786,7 @@ func TestRenderLogs_IdleWithURL(t *testing.T) {
 	m.running = false
 	m.urlInput.SetValue("https://example.com/api")
 
-	out := m.renderLogs(94, 20)
+	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("idle empty logs should show Logs identity")
 	}
@@ -803,7 +829,7 @@ func TestRenderPayload_Identity(t *testing.T) {
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Payload") {
 		t.Fatal("payload should show identity header")
 	}
@@ -827,7 +853,7 @@ func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 	m.dialog = dialogPayload
 	m.selectedHead = 0
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Payload") {
 		t.Fatal("payload should show identity header")
 	}
@@ -845,7 +871,7 @@ func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Payload") {
 		t.Fatal("payload should show identity header")
 	}
@@ -857,7 +883,7 @@ func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 func TestRenderEndpoint_Identity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderEndpoint(100)
+	out := m.renderEndpoint(Region{Width: 100, Height: 20})
 	if !contains(t, out, "Endpoint") {
 		t.Fatal("endpoint should show identity header")
 	}
@@ -876,7 +902,7 @@ func TestRenderConcurrency_Identity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.setConcurrency(7)
-	out := m.renderConcurrency(100)
+	out := m.renderConcurrency(Region{Width: 100, Height: 20})
 	if !contains(t, out, "Concurrency") {
 		t.Fatal("concurrency should show identity header")
 	}
@@ -895,7 +921,7 @@ func TestRenderEndpoint_Focused(t *testing.T) {
 	m.urlInput.Focus()
 	m.urlInput.SetValue("https://example.com/api")
 
-	out := m.renderEndpoint(100)
+	out := m.renderEndpoint(Region{Width: 100, Height: 20})
 	if !contains(t, out, "Endpoint") {
 		t.Fatal("should show identity")
 	}
@@ -914,7 +940,7 @@ func TestRenderConcurrency_Focused(t *testing.T) {
 	m.ccInput.Focus()
 	m.setConcurrency(7)
 
-	out := m.renderConcurrency(100)
+	out := m.renderConcurrency(Region{Width: 100, Height: 20})
 	if !contains(t, out, "Concurrency") {
 		t.Fatal("should show identity")
 	}
@@ -937,7 +963,7 @@ func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 	m.headers[0].Key.Focus()
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Content-Type") {
 		t.Fatal("should show header key")
 	}
@@ -963,7 +989,7 @@ func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 	m.headers[0].Value.SetValue("application/json")
 	m.headers[0].Value.Focus()
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Content-Type") {
 		t.Fatal("should show header key")
 	}
@@ -987,12 +1013,26 @@ func TestRenderPayload_BodyFocus(t *testing.T) {
 	m.bodyInput.SetValue(`{"key": "value"}`)
 	m.headers = append(m.headers, newHeaderRow())
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, `{"key": "value"}`) {
 		t.Fatal("should show body content")
 	}
 	if !m.bodyInput.Focused() {
 		t.Fatal("bodyInput should be focused when selectedHead is bodyFocus")
+	}
+}
+
+func TestRenderCurrentSurface_DispatchesToSurface(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+
+	region := Region{Width: 100, Height: 26}
+
+	// Ready state
+	out := m.renderCurrentSurface(region)
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("renderCurrentSurface should render Ready when idle")
 	}
 }
 
@@ -1049,7 +1089,7 @@ func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 	m.headers[1].Value.SetValue("application/json")
 	m.selectedHead = 1
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Authorization") {
 		t.Fatal("payload should show first header key")
 	}
@@ -1069,7 +1109,7 @@ func TestRenderPayload_BodyFocusColor(t *testing.T) {
 	m.selectedHead = bodyFocus
 	m.headers = append(m.headers, newHeaderRow())
 
-	out := m.renderPayload(96)
+	out := m.renderPayload(Region{Width: 96, Height: 20})
 	if !contains(t, out, "BODY") {
 		t.Fatal("payload should show BODY label")
 	}
@@ -1080,17 +1120,17 @@ func TestRenderStatusBar_PayloadDialog(t *testing.T) {
 	m.width = 100
 	m.dialog = dialogPayload
 	out := m.renderStatusBar(100)
-	if !contains(t, out, "Tab Next") {
-		t.Fatal("payload status bar should show Tab Next hint")
+	if !contains(t, out, "[Tab] Next") {
+		t.Fatal("payload status bar should show [Tab] Next")
 	}
-	if !contains(t, out, "Ctrl+N") {
-		t.Fatal("payload status bar should show Ctrl+N hint")
+	if !contains(t, out, "[Ctrl+N] Header") {
+		t.Fatal("payload status bar should show [Ctrl+N] Header")
 	}
-	if !contains(t, out, "Ctrl+D") {
-		t.Fatal("payload status bar should show Ctrl+D hint")
+	if !contains(t, out, "[Ctrl+D] Delete") {
+		t.Fatal("payload status bar should show [Ctrl+D] Delete")
 	}
-	if !contains(t, out, "Esc Back") {
-		t.Fatal("payload status bar should show Esc Back hint")
+	if !contains(t, out, "[Esc] Back") {
+		t.Fatal("payload status bar should show [Esc] Back")
 	}
 }
 
@@ -1108,6 +1148,31 @@ func TestConfirmQuit_PreservesWorkspace(t *testing.T) {
 	// Body content should still be visible (Timeline identity preserved)
 	if !contains(t, out, "Timeline") {
 		t.Fatal("confirm quit should preserve workspace identity")
+	}
+}
+
+func TestPayloadSummary(t *testing.T) {
+	m := NewModel()
+	tt := []struct {
+		headers int
+		body    string
+		want    string
+	}{
+		{0, "", "—"},
+		{1, "", "1H"},
+		{0, "body", "B"},
+		{2, "body", "2H+B"},
+	}
+	for _, tc := range tt {
+		m.headers = nil
+		for i := 0; i < tc.headers; i++ {
+			m.headers = append(m.headers, newHeaderRow())
+		}
+		m.bodyInput.SetValue(tc.body)
+		got := m.payloadSummary()
+		if got != tc.want {
+			t.Errorf("payloadSummary(%d headers, %q) = %q (expected %q)", tc.headers, tc.body, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Introduce Shell + Workspace architecture with stable layout ownership.

ShellLayout (Region, computeShellLayout):
- Three permanent regions: Context, Workspace, Command
- Every surface fills the workspace region identically
- Dialog renderers (Endpoint, Concurrency, Payload) fill allocated height, anchoring the footer consistently

renderCurrentSurface:
- Explicit dispatch replacing inline switch in View()
- Named to avoid collision when Workspace becomes an object
- All 7 workspace renderers accept Region (not raw w/h)

Command ribbon:
- Each command rendered as [key] Label with · separators
- 2-space left margin (horizontal inset)
- Applies across all 8 states consistently

Context payload summary:
- Standardized grammar: Payload — / B / 2H / 2H+B
- Never prose, never plurals, never "Empty"
- Shown in top bar when width >= 100columns

go fmt alignment cleanup in model.go (struct fields, NewModel).