### PR TITLE
v0.8.7: Shell Runtime Stabilization

### DIFF
--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -16,7 +16,7 @@ const (
 var (
 	styleBase       = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
 	styleTopBar     = styleBase.Copy().Bold(true)
-	styleStatusBar  = styleBase.Copy().Background(lipgloss.Color(colorDark))
+	styleRibbon     = styleBase.Copy().Background(lipgloss.Color(colorDark))
 	styleStatusMode = lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorBg)).Bold(true)
 	styleSeparator  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	styleMuted      = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -41,12 +41,12 @@ func TestStyleBase(t *testing.T) {
 	}
 }
 
-func TestStyleStatusBar(t *testing.T) {
-	if got := styleStatusBar.GetForeground(); got != lipgloss.Color(colorText) {
-		t.Errorf("styleStatusBar foreground = %q, want %q", got, colorText)
+func TestStyleRibbon(t *testing.T) {
+	if got := styleRibbon.GetForeground(); got != lipgloss.Color(colorText) {
+		t.Errorf("styleRibbon foreground = %q, want %q", got, colorText)
 	}
-	if got := styleStatusBar.GetBackground(); got != lipgloss.Color(colorDark) {
-		t.Errorf("styleStatusBar background = %q, want %q", got, colorDark)
+	if got := styleRibbon.GetBackground(); got != lipgloss.Color(colorDark) {
+		t.Errorf("styleRibbon background = %q, want %q", got, colorDark)
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -32,15 +32,224 @@ func computeShellLayout(totalWidth, totalHeight int) ShellLayout {
 	}
 }
 
+// ShellColumnWidth is the fixed width reserved for the orientation label
+// in the operator ribbon. Actions always start at Column 19
+// (ShellColumnWidth + 2-char gutter + 1 space).
+const ShellColumnWidth = 16
+
+// ActionCategory defines the four semantic groups an action can belong to.
+// Categories are ordered by priority. Empty categories are omitted.
+type ActionCategory int
+
+const (
+	NavigationCategory ActionCategory = iota
+	ConfigurationCategory
+	OperationCategory
+	ApplicationCategory
+)
+
+// ActionID identifies an operator intent. The workspace exposes which actions
+// currently exist; the ribbon layer maps them to presentation.
+type ActionID int
+
+const (
+	ActionSelect ActionID = iota
+	ActionInspect
+	ActionSwitchView
+	ActionConfigureEndpoint
+	ActionConfigureConcurrency
+	ActionConfigurePayload
+	ActionRun
+	ActionCancel
+	ActionNextField
+	ActionSwitchMethod
+	ActionAdjustConcurrency
+	ActionNextHeader
+	ActionAddHeader
+	ActionDeleteHeader
+	ActionBack
+	ActionQuit
+	ActionConfirmQuit
+	ActionCtrlCQuit
+	ActionQQuit
+	ActionDismissCancel
+)
+
+// Action is a behavioral intent — not a presentation object.
+// The workspace produces actions; the ribbon derives presentation from them.
+type Action struct {
+	ID       ActionID
+	Category ActionCategory
+	Enabled  bool
+}
+
+// configItem represents a single configuration value in the Context region.
+// The contract is Identity, Value, Validity — presentation is a shell concern.
+type configItem struct {
+	Identity string
+	Value    string
+	Valid    bool
+}
+
+// ShellState is an immutable snapshot of the shell-level state produced once
+// per frame. Every shell renderer consumes this instead of reading model
+// fields independently, eliminating duplicate state lookups.
+type ShellState struct {
+	Orientation   string
+	Configuration []configItem
+	Actions       []Action
+}
+
+// actionBinding maps an operator intent (ActionID) to its presentation in the
+// operator ribbon. This is the single source of truth for shortcut-to-intent
+// mapping. All [Ctrl+R], [Esc], [Tab], etc. live here.
+type actionBinding struct {
+	Key      string
+	Label    string
+	Category ActionCategory
+}
+
+var actionBindings = map[ActionID]actionBinding{
+	ActionSelect:               {"↑↓", "Select", NavigationCategory},
+	ActionInspect:              {"Enter", "Inspect", NavigationCategory},
+	ActionSwitchView:           {"Tab", "Views", NavigationCategory},
+	ActionConfigureEndpoint:    {"e", "Endpoint", ConfigurationCategory},
+	ActionConfigureConcurrency: {"c", "Concurrency", ConfigurationCategory},
+	ActionConfigurePayload:     {"p", "Payload", ConfigurationCategory},
+	ActionRun:                  {"Ctrl+R", "Run", OperationCategory},
+	ActionCancel:               {"Ctrl+X", "Cancel", OperationCategory},
+	ActionNextField:            {"Tab", "Next Field", ConfigurationCategory},
+	ActionSwitchMethod:         {"←→", "Method", ConfigurationCategory},
+	ActionAdjustConcurrency:    {"↑↓", "Adjust", ConfigurationCategory},
+	ActionNextHeader:           {"Tab", "Next", ConfigurationCategory},
+	ActionAddHeader:            {"Ctrl+N", "Header", ConfigurationCategory},
+	ActionDeleteHeader:         {"Ctrl+D", "Delete", ConfigurationCategory},
+	ActionBack:                 {"Esc", "Back", ApplicationCategory},
+	ActionQuit:                 {"q", "Quit", ApplicationCategory},
+	ActionConfirmQuit:          {"Enter", "Quit", ApplicationCategory},
+	ActionCtrlCQuit:            {"Ctrl+C", "Quit", ApplicationCategory},
+	ActionQQuit:                {"q", "Quit", ApplicationCategory},
+	ActionDismissCancel:        {"Any", "Cancel", ApplicationCategory},
+}
+
+func (m Model) orientationLabel() string {
+	switch {
+	case m.dialog == dialogConfirmQuit:
+		return "QUIT"
+	case m.dialog == dialogEndpoint:
+		return "ENDPOINT"
+	case m.dialog == dialogConcurrency:
+		return "CONCURRENCY"
+	case m.dialog == dialogPayload:
+		return "PAYLOAD"
+	case m.mode == modeInspect:
+		return "INSPECT"
+	case !m.running && len(m.results) == 0:
+		return "OBSERVE"
+	case m.view == viewTimeline:
+		return "TIMELINE"
+	default:
+		return "LOGS"
+	}
+}
+
+func (m Model) Actions() []Action {
+	switch {
+	case m.dialog == dialogConfirmQuit:
+		return []Action{
+			{ActionConfirmQuit, ApplicationCategory, true},
+			{ActionCtrlCQuit, ApplicationCategory, true},
+			{ActionQQuit, ApplicationCategory, true},
+			{ActionDismissCancel, ApplicationCategory, true},
+		}
+	case m.dialog == dialogEndpoint:
+		return []Action{
+			{ActionNextField, ConfigurationCategory, true},
+			{ActionSwitchMethod, ConfigurationCategory, true},
+			{ActionBack, ApplicationCategory, true},
+		}
+	case m.dialog == dialogConcurrency:
+		return []Action{
+			{ActionAdjustConcurrency, ConfigurationCategory, true},
+			{ActionBack, ApplicationCategory, true},
+		}
+	case m.dialog == dialogPayload:
+		return []Action{
+			{ActionNextHeader, ConfigurationCategory, true},
+			{ActionAddHeader, ConfigurationCategory, true},
+			{ActionDeleteHeader, ConfigurationCategory, true},
+			{ActionBack, ApplicationCategory, true},
+		}
+	case m.mode == modeInspect:
+		return []Action{
+			{ActionSelect, NavigationCategory, true},
+			{ActionBack, ApplicationCategory, true},
+			{ActionQuit, ApplicationCategory, true},
+		}
+	case m.running && len(m.results) == 0:
+		return []Action{
+			{ActionCancel, OperationCategory, true},
+		}
+	case m.running:
+		return []Action{
+			{ActionSelect, NavigationCategory, true},
+			{ActionInspect, NavigationCategory, true},
+			{ActionSwitchView, NavigationCategory, true},
+			{ActionCancel, OperationCategory, true},
+		}
+	case !m.running && len(m.results) == 0:
+		return []Action{
+			{ActionConfigureEndpoint, ConfigurationCategory, true},
+			{ActionConfigureConcurrency, ConfigurationCategory, true},
+			{ActionConfigurePayload, ConfigurationCategory, true},
+			{ActionRun, OperationCategory, true},
+			{ActionQuit, ApplicationCategory, true},
+		}
+	default:
+		return []Action{
+			{ActionSelect, NavigationCategory, true},
+			{ActionInspect, NavigationCategory, true},
+			{ActionSwitchView, NavigationCategory, true},
+			{ActionConfigureEndpoint, ConfigurationCategory, true},
+			{ActionConfigureConcurrency, ConfigurationCategory, true},
+			{ActionConfigurePayload, ConfigurationCategory, true},
+			{ActionRun, OperationCategory, true},
+			{ActionQuit, ApplicationCategory, true},
+		}
+	}
+}
+
+func (m Model) Configuration() []configItem {
+	ps := m.payloadSummary()
+	items := []configItem{
+		{"Method", runconfig.AllowedMethods()[m.methodIndex], true},
+		{"URL", m.urlInput.Value(), m.urlInput.Value() != ""},
+		{"CC", strings.TrimSpace(m.ccInput.Value()), true},
+	}
+	if ps != "—" {
+		items = append(items, configItem{"Payload", ps, true})
+	}
+	return items
+}
+
+func (m Model) ShellState() ShellState {
+	return ShellState{
+		Orientation:   m.orientationLabel(),
+		Configuration: m.Configuration(),
+		Actions:       m.Actions(),
+	}
+}
+
 func (m Model) View() string {
 	if m.width == 0 {
 		return "Pulse is starting..."
 	}
 
 	layout := computeShellLayout(m.width, m.height)
+	state := m.ShellState()
 
 	var sb strings.Builder
-	sb.WriteString(m.renderTopBar(layout.Context.Width))
+	sb.WriteString(m.renderTopBar(state, layout.Context.Width))
 	sb.WriteString("\n")
 	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Context.Width)))
 	sb.WriteString("\n")
@@ -48,7 +257,7 @@ func (m Model) View() string {
 	sb.WriteString("\n")
 	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Command.Width)))
 	sb.WriteString("\n")
-	sb.WriteString(m.renderStatusBar(layout.Command.Width))
+	sb.WriteString(m.renderRibbon(state, layout.Command.Width))
 
 	return styleBase.Width(layout.Context.Width).Height(m.height).Render(sb.String())
 }
@@ -107,17 +316,23 @@ func (m Model) payloadSummary() string {
 	}
 }
 
-func (m Model) renderTopBar(width int) string {
-	method := runconfig.AllowedMethods()[m.methodIndex]
-	url := truncateURL(m.urlInput.Value(), 40)
-	left := method + " " + url
-
-	cc := strings.TrimSpace(m.ccInput.Value())
-	right := "CC " + cc
-
-	ps := m.payloadSummary()
-	if ps != "—" && width >= 100 {
-		right += " · Payload " + ps
+func (m Model) renderTopBar(state ShellState, width int) string {
+	cfg := state.Configuration
+	left := ""
+	right := ""
+	for _, c := range cfg {
+		switch c.Identity {
+		case "Method":
+			left = c.Value
+		case "URL":
+			left += " " + truncateURL(c.Value, 40)
+		case "CC":
+			right = "CC " + c.Value
+		case "Payload":
+			if width >= 100 {
+				right += " · Payload " + c.Value
+			}
+		}
 	}
 
 	maxLeft := width - lipgloss.Width(right) - 3
@@ -250,31 +465,49 @@ func (m Model) renderPayload(region Region) string {
 	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderStatusBar(width int) string {
-	var hints string
+func (m Model) renderRibbon(state ShellState, width int) string {
+	label := state.Orientation
+	actions := state.Actions
 
-	switch {
-	case m.dialog == dialogConfirmQuit:
-		hints = "  [Enter]  [q]  [Ctrl+C] to quit  ·  any key cancels"
-	case m.dialog == dialogEndpoint:
-		hints = "  [Tab] Next Field  ·  [←→] Method  ·  [Esc] Back"
-	case m.dialog == dialogConcurrency:
-		hints = "  [↑↓] Adjust  ·  [Esc] Back"
-	case m.dialog == dialogPayload:
-		hints = "  [Tab] Next  ·  [Ctrl+N] Header  ·  [Ctrl+D] Delete  ·  [Esc] Back"
-	case m.mode == modeInspect:
-		hints = "  [↑↓] Select  ·  [Esc] Back  ·  [q] Quit"
-	case m.running && len(m.results) == 0:
-		hints = "  [Ctrl+X] Cancel"
-	case m.running:
-		hints = "  [↑↓] Select  ·  [Enter] Inspect  ·  [Tab] Views  ·  [Ctrl+X] Cancel"
-	case !m.running && len(m.results) == 0:
-		hints = "  [e] Endpoint  ·  [c] Concurrency  ·  [p] Payload  ·  [Ctrl+R] Run  ·  [q] Quit"
-	default:
-		hints = "  [↑↓] Select  ·  [Enter] Inspect  ·  [Tab] Views  ·  [e] Endpoint  ·  [c] Concurrency  ·  [p] Payload  ·  [Ctrl+R] Run  ·  [q] Quit"
+	type cmd struct {
+		key      string
+		label    string
+		category ActionCategory
 	}
 
-	return styleStatusBar.Width(width).Render(hints)
+	groups := make([][]cmd, 4)
+	for _, a := range actions {
+		b := actionBindings[a.ID]
+		c := cmd{key: b.Key, label: b.Label, category: b.Category}
+		groups[b.Category] = append(groups[b.Category], c)
+	}
+
+	var actionParts []string
+	for _, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+		var parts []string
+		for _, c := range group {
+			parts = append(parts, fmt.Sprintf("[%s] %s", c.key, c.label))
+		}
+		actionParts = append(actionParts, strings.Join(parts, " · "))
+	}
+
+	actionColumn := strings.Join(actionParts, "    ")
+
+	var ribbonParts []string
+	ribbonParts = append(ribbonParts, fmt.Sprintf("%-*s", ShellColumnWidth, label))
+	if actionColumn != "" {
+		ribbonParts = append(ribbonParts, actionColumn)
+	}
+	ribbonLine := strings.Join(ribbonParts, "  ")
+
+	if w := lipgloss.Width(ribbonLine); w < width {
+		ribbonLine += strings.Repeat(" ", width-w)
+	}
+
+	return styleRibbon.Width(width).Render(ribbonLine)
 }
 
 func visibleWindow(total, selected, height int) int {
@@ -483,7 +716,7 @@ func (m Model) renderEmptyState(runningMsg string) string {
 		if strings.TrimSpace(m.urlInput.Value()) == "" {
 			return "Enter a URL to begin"
 		}
-		return "▶  Ctrl+R to run"
+		return "▶  Ready"
 	}
 	return runningMsg
 }

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -91,7 +91,7 @@ func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 func TestRenderTopBar_ShowsMethodAndURL(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderTopBar(100)
+	out := m.renderTopBar(m.ShellState(), 100)
 	if !contains(t, out, "GET") {
 		t.Fatal("top bar should contain method")
 	}
@@ -108,7 +108,7 @@ func TestRenderTopBar_ShowsPayloadSummary(t *testing.T) {
 	m.headers[0].Value.SetValue("application/json")
 	m.bodyInput.SetValue(`{"key": "value"}`)
 
-	out := m.renderTopBar(120)
+	out := m.renderTopBar(m.ShellState(), 120)
 	if !contains(t, out, "Payload") {
 		t.Fatal("top bar should show payload summary when width permits")
 	}
@@ -120,7 +120,7 @@ func TestRenderTopBar_ShowsPayloadSummary(t *testing.T) {
 func TestRenderTopBar_ShowsCC(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderTopBar(100)
+	out := m.renderTopBar(m.ShellState(), 100)
 	if !contains(t, out, "CC") {
 		t.Fatal("top bar should show CC")
 	}
@@ -130,7 +130,7 @@ func TestRenderTopBar_QueryTruncation(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.urlInput.SetValue("https://api.example.com/users?page=1")
-	out := m.renderTopBar(100)
+	out := m.renderTopBar(m.ShellState(), 100)
 	if contains(t, out, "?page=1") {
 		t.Fatal("top bar should truncate query string from URL")
 	}
@@ -255,56 +255,56 @@ func TestMetricsString_RunningEmpty(t *testing.T) {
 	}
 }
 
-func TestRenderStatusBar_Normal(t *testing.T) {
+func TestRenderRibbon_Normal(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[↑↓] Select") {
-		t.Fatal("post-run status bar should show scroll hint")
+		t.Fatal("post-run ribbon should show scroll hint")
 	}
 	if !contains(t, out, "[Tab] Views") {
-		t.Fatal("post-run status bar should show view switch command")
+		t.Fatal("post-run ribbon should show view switch command")
 	}
 }
 
-func TestRenderStatusBar_Ready(t *testing.T) {
+func TestRenderRibbon_Ready(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[e] Endpoint") {
-		t.Fatal("ready status bar should show [e] Endpoint")
+		t.Fatal("ready ribbon should show [e] Endpoint")
 	}
 	if !contains(t, out, "[c] Concurrency") {
-		t.Fatal("ready status bar should show [c] Concurrency")
+		t.Fatal("ready ribbon should show [c] Concurrency")
 	}
 	if !contains(t, out, "[p] Payload") {
-		t.Fatal("ready status bar should show [p] Payload")
+		t.Fatal("ready ribbon should show [p] Payload")
 	}
 	if contains(t, out, "[↑↓]") {
-		t.Fatal("ready status bar should not advertise [↑↓] (inert)")
+		t.Fatal("ready ribbon should not advertise [↑↓] (inert)")
 	}
 	if contains(t, out, "[Enter]") {
-		t.Fatal("ready status bar should not advertise [Enter] (inert)")
+		t.Fatal("ready ribbon should not advertise [Enter] (inert)")
 	}
 	if contains(t, out, "[Tab]") {
-		t.Fatal("ready status bar should not advertise [Tab] (inert)")
+		t.Fatal("ready ribbon should not advertise [Tab] (inert)")
 	}
 	if !contains(t, out, "[Ctrl+R]") {
-		t.Fatal("ready status bar should show [Ctrl+R]")
+		t.Fatal("ready ribbon should show [Ctrl+R]")
 	}
 	if !contains(t, out, "[q] Quit") {
-		t.Fatal("ready status bar should show [q] Quit")
+		t.Fatal("ready ribbon should show [q] Quit")
 	}
 }
 
-func TestRenderStatusBar_RunningEmpty(t *testing.T) {
+func TestRenderRibbon_RunningEmpty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "Ctrl+X") {
-		t.Fatal("running empty status bar should show Ctrl+X")
+		t.Fatal("running empty ribbon should show Ctrl+X")
 	}
 	if contains(t, out, "↑↓") {
 		t.Fatal("running empty should not advertise ↑↓ (inert)")
@@ -314,72 +314,72 @@ func TestRenderStatusBar_RunningEmpty(t *testing.T) {
 	}
 }
 
-func TestRenderStatusBar_RunningWithResults(t *testing.T) {
+func TestRenderRibbon_RunningWithResults(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Enter] Inspect") {
-		t.Fatal("running status bar should show [Enter] Inspect")
+		t.Fatal("running ribbon should show [Enter] Inspect")
 	}
 	if !contains(t, out, "[Tab] Views") {
-		t.Fatal("running status bar should show [Tab] Views")
+		t.Fatal("running ribbon should show [Tab] Views")
 	}
 	if !contains(t, out, "[Ctrl+X]") {
-		t.Fatal("running status bar should show [Ctrl+X] Cancel")
+		t.Fatal("running ribbon should show [Ctrl+X] Cancel")
 	}
 }
 
-func TestRenderStatusBar_EndpointDialog(t *testing.T) {
+func TestRenderRibbon_EndpointDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.dialog = dialogEndpoint
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("endpoint status bar should show [Esc] Back")
+		t.Fatal("endpoint ribbon should show [Esc] Back")
 	}
 	if !contains(t, out, "[Tab] Next Field") {
-		t.Fatal("endpoint status bar should show [Tab] Next Field")
+		t.Fatal("endpoint ribbon should show [Tab] Next Field")
 	}
 	if !contains(t, out, "[←→] Method") {
-		t.Fatal("endpoint status bar should show [←→] Method")
+		t.Fatal("endpoint ribbon should show [←→] Method")
 	}
 }
 
-func TestRenderStatusBar_CCDialog(t *testing.T) {
+func TestRenderRibbon_CCDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.dialog = dialogConcurrency
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("concurrency status bar should show [Esc] Back")
+		t.Fatal("concurrency ribbon should show [Esc] Back")
 	}
 	if !contains(t, out, "[↑↓] Adjust") {
-		t.Fatal("concurrency status bar should show [↑↓] Adjust")
+		t.Fatal("concurrency ribbon should show [↑↓] Adjust")
 	}
 }
 
-func TestRenderStatusBar_Inspecting(t *testing.T) {
+func TestRenderRibbon_Inspecting(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.mode = modeInspect
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("inspect status bar should show [Esc] Back")
+		t.Fatal("inspect ribbon should show [Esc] Back")
 	}
 	if !contains(t, out, "[q] Quit") {
-		t.Fatal("inspect status bar should show [q] Quit")
+		t.Fatal("inspect ribbon should show [q] Quit")
 	}
 }
 
-func TestRenderStatusBar_QuitConfirm(t *testing.T) {
+func TestRenderRibbon_QuitConfirm(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.dialog = dialogConfirmQuit
-	out := m.renderStatusBar(100)
-	if !contains(t, out, "quit") {
-		t.Fatal("status bar should show quit confirmation")
+	out := m.renderRibbon(m.ShellState(), 100)
+	if !contains(t, out, "Quit") {
+		t.Fatal("ribbon should show quit confirmation")
 	}
 	if !contains(t, out, "Enter") {
 		t.Fatal("quit confirm should mention Enter as confirm option")
@@ -408,7 +408,7 @@ func TestRenderTimeline_Empty(t *testing.T) {
 	if !contains(t, out, "Timeline") {
 		t.Fatal("empty timeline should show Timeline identity")
 	}
-	if !contains(t, out, "▶  Ctrl+R to run") {
+	if !contains(t, out, "▶  Ready") {
 		t.Fatal("empty timeline should show '▶  Ctrl+R to run'")
 	}
 }
@@ -457,7 +457,7 @@ func TestRenderLogs_Empty(t *testing.T) {
 	if !contains(t, out, "Logs") {
 		t.Fatal("empty logs should show Logs identity")
 	}
-	if !contains(t, out, "▶  Ctrl+R to run") {
+	if !contains(t, out, "▶  Ready") {
 		t.Fatal("empty logs should show '▶  Ctrl+R to run'")
 	}
 }
@@ -745,7 +745,7 @@ func TestRenderTimeline_IdleWithURL(t *testing.T) {
 	if !contains(t, out, "Timeline") {
 		t.Fatal("idle empty timeline should show Timeline identity")
 	}
-	if !contains(t, out, "▶  Ctrl+R to run") {
+	if !contains(t, out, "▶  Ready") {
 		t.Fatal("idle empty timeline with URL should show '▶  Ctrl+R to run'")
 	}
 }
@@ -790,7 +790,7 @@ func TestRenderLogs_IdleWithURL(t *testing.T) {
 	if !contains(t, out, "Logs") {
 		t.Fatal("idle empty logs should show Logs identity")
 	}
-	if !contains(t, out, "▶  Ctrl+R to run") {
+	if !contains(t, out, "▶  Ready") {
 		t.Fatal("idle empty logs with URL should show '▶  Ctrl+R to run'")
 	}
 }
@@ -1115,22 +1115,22 @@ func TestRenderPayload_BodyFocusColor(t *testing.T) {
 	}
 }
 
-func TestRenderStatusBar_PayloadDialog(t *testing.T) {
+func TestRenderRibbon_PayloadDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.dialog = dialogPayload
-	out := m.renderStatusBar(100)
+	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Tab] Next") {
-		t.Fatal("payload status bar should show [Tab] Next")
+		t.Fatal("payload ribbon should show [Tab] Next")
 	}
 	if !contains(t, out, "[Ctrl+N] Header") {
-		t.Fatal("payload status bar should show [Ctrl+N] Header")
+		t.Fatal("payload ribbon should show [Ctrl+N] Header")
 	}
 	if !contains(t, out, "[Ctrl+D] Delete") {
-		t.Fatal("payload status bar should show [Ctrl+D] Delete")
+		t.Fatal("payload ribbon should show [Ctrl+D] Delete")
 	}
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("payload status bar should show [Esc] Back")
+		t.Fatal("payload ribbon should show [Esc] Back")
 	}
 }
 
@@ -1172,6 +1172,510 @@ func TestPayloadSummary(t *testing.T) {
 		got := m.payloadSummary()
 		if got != tc.want {
 			t.Errorf("payloadSummary(%d headers, %q) = %q (expected %q)", tc.headers, tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestOrientationLabel_Ready(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("ready orientationLabel = %q, want OBSERVE", got)
+	}
+}
+
+func TestOrientationLabel_WithResults(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if got := m.orientationLabel(); got != "TIMELINE" {
+		t.Fatalf("results orientationLabel = %q, want TIMELINE", got)
+	}
+}
+
+func TestOrientationLabel_RunningEmpty(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	if got := m.orientationLabel(); got != "TIMELINE" {
+		t.Fatalf("running empty orientationLabel = %q, want TIMELINE", got)
+	}
+}
+
+func TestOrientationLabel_RunningWithResults(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if got := m.orientationLabel(); got != "TIMELINE" {
+		t.Fatalf("running+results orientationLabel = %q, want TIMELINE", got)
+	}
+}
+
+func TestOrientationLabel_LogsView(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.view = viewLogs
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if got := m.orientationLabel(); got != "LOGS" {
+		t.Fatalf("logs view orientationLabel = %q, want LOGS", got)
+	}
+}
+
+func TestOrientationLabel_RunningLogsView(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.view = viewLogs
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if got := m.orientationLabel(); got != "LOGS" {
+		t.Fatalf("running+logs orientationLabel = %q, want LOGS", got)
+	}
+}
+
+func TestOrientationLabel_EndpointDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogEndpoint
+	if got := m.orientationLabel(); got != "ENDPOINT" {
+		t.Fatalf("endpoint dialog orientationLabel = %q, want ENDPOINT", got)
+	}
+}
+
+func TestOrientationLabel_ConcurrencyDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogConcurrency
+	if got := m.orientationLabel(); got != "CONCURRENCY" {
+		t.Fatalf("concurrency dialog orientationLabel = %q, want CONCURRENCY", got)
+	}
+}
+
+func TestOrientationLabel_PayloadDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogPayload
+	if got := m.orientationLabel(); got != "PAYLOAD" {
+		t.Fatalf("payload dialog orientationLabel = %q, want PAYLOAD", got)
+	}
+}
+
+func TestOrientationLabel_InspectMode(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.mode = modeInspect
+	if got := m.orientationLabel(); got != "INSPECT" {
+		t.Fatalf("inspect mode orientationLabel = %q, want INSPECT", got)
+	}
+}
+
+func TestOrientationLabel_QuitDialog(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.dialog = dialogConfirmQuit
+	if got := m.orientationLabel(); got != "QUIT" {
+		t.Fatalf("quit dialog orientationLabel = %q, want QUIT", got)
+	}
+}
+
+func TestRenderRibbon_ShellColumnWidth(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderRibbon(m.ShellState(), 100)
+	// Shell column must contain orientation label right-padded to ShellColumnWidth.
+	// "OBSERVE        " (7 + 9 padding = 16) followed by gutter "  ".
+	if !contains(t, out, "OBSERVE        ") {
+		t.Fatal("ribbon should right-pad OBSERVE to ShellColumnWidth (16)")
+	}
+}
+
+func TestRenderRibbon_EmptyGroupsOmitted(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderRibbon(m.ShellState(), 100)
+	// Ready state has no Navigation commands — must not render "[↑↓]" or "[Enter] Inspect".
+	if contains(t, out, "[↑↓]") {
+		t.Fatal("ribbon should omit empty Navigation group in ready state")
+	}
+}
+
+func TestRenderRibbon_CategoryOrder(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	out := m.renderRibbon(m.ShellState(), 100)
+	// With results: Navigation → Configuration → Operation → Application.
+	// Navigation must appear before Configuration.
+	navIdx := strings.Index(out, "[↑↓] Select")
+	cfgIdx := strings.Index(out, "[e] Endpoint")
+	if navIdx < 0 {
+		t.Fatal("ribbon should include [↑↓] Select when results exist")
+	}
+	if cfgIdx < 0 {
+		t.Fatal("ribbon should include [e] Endpoint when results exist")
+	}
+	if navIdx > cfgIdx {
+		t.Fatal("Navigation group must render before Configuration group")
+	}
+}
+
+func TestRenderRibbon_WithinGroupSeparator(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderRibbon(m.ShellState(), 100)
+	// Ready state: [e] Endpoint, [c] Concurrency, [p] Payload — all in Configuration group.
+	// They must be separated by " · " (space-bullet-space).
+	if !contains(t, out, "[e] Endpoint · [c] Concurrency · [p] Payload") {
+		t.Fatal("commands within same category should be separated by ' · '")
+	}
+}
+
+func TestRenderRibbon_BetweenGroupSeparator(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	out := m.renderRibbon(m.ShellState(), 100)
+	// Ready state: Configuration group followed by Operation group.
+	// Must have 4-space gap between groups.
+	if !contains(t, out, "Payload    [Ctrl+R]") {
+		t.Fatal("different category groups must be separated by wider gap (4 spaces)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Architectural invariant tests — ownership rules, not content
+// ---------------------------------------------------------------------------
+
+// TestShellInvariant_WorkspaceNoSeparators verifies workspace surface renderers
+// never produce shell separator characters (─). Separators are Shell-owned.
+func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
+	region := Region{Width: 100, Height: 26}
+
+	// renderReady
+	m := NewModel()
+	m.width = 100
+	if contains(t, m.renderReady(region), "─") {
+		t.Fatal("renderReady must not render shell separators")
+	}
+
+	// renderEndpoint
+	m2 := NewModel()
+	m2.width = 100
+	m2.dialog = dialogEndpoint
+	if contains(t, m2.renderEndpoint(region), "─") {
+		t.Fatal("renderEndpoint must not render shell separators")
+	}
+
+	// renderConcurrency
+	m3 := NewModel()
+	m3.width = 100
+	m3.dialog = dialogConcurrency
+	if contains(t, m3.renderConcurrency(region), "─") {
+		t.Fatal("renderConcurrency must not render shell separators")
+	}
+
+	// renderPayload
+	m4 := NewModel()
+	m4.width = 100
+	m4.dialog = dialogPayload
+	if contains(t, m4.renderPayload(region), "─") {
+		t.Fatal("renderPayload must not render shell separators")
+	}
+
+	// renderTimeline
+	m5 := NewModel()
+	m5.width = 100
+	m5.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m5.renderTimeline(region), "─") {
+		t.Fatal("renderTimeline must not render shell separators")
+	}
+
+	// renderLogs
+	m6 := NewModel()
+	m6.width = 100
+	m6.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m6.renderLogs(region), "─") {
+		t.Fatal("renderLogs must not render shell separators")
+	}
+
+	// renderInspect
+	m7 := NewModel()
+	m7.width = 100
+	m7.selected = 0
+	m7.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m7.renderInspect(Region{Width: 40, Height: 20}), "─") {
+		t.Fatal("renderInspect must not render shell separators")
+	}
+}
+
+// TestShellInvariant_WorkspaceNoShortcuts verifies workspace surface renderers
+// never bake keyboard shortcuts into body content. Shortcuts belong in the
+// ribbon, which is Shell-owned.
+func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
+	region := Region{Width: 100, Height: 26}
+
+	shortcutPatterns := []string{"Ctrl+", "[Esc]", "[Tab]", "[Enter]", "[↑↓]", "[←→]", "[q]", "[e]", "[c]", "[p]"}
+
+	m := NewModel()
+	m.width = 100
+	out := m.renderCurrentSurface(region)
+	for _, pat := range shortcutPatterns {
+		if contains(t, out, pat) {
+			t.Fatalf("Workspace must not contain %q (shortcuts belong in ribbon)", pat)
+		}
+	}
+
+	// Verify all dialog surfaces also follow this rule.
+	m2 := NewModel()
+	m2.width = 100
+	m2.dialog = dialogEndpoint
+	for _, pat := range shortcutPatterns {
+		if contains(t, m2.renderEndpoint(region), pat) {
+			t.Fatalf("Endpoint surface must not contain %q", pat)
+		}
+	}
+
+	m3 := NewModel()
+	m3.width = 100
+	m3.dialog = dialogConcurrency
+	for _, pat := range shortcutPatterns {
+		if contains(t, m3.renderConcurrency(region), pat) {
+			t.Fatalf("Concurrency surface must not contain %q", pat)
+		}
+	}
+}
+
+// TestShellInvariant_RibbonHasOrientation verifies every ribbon output starts
+// with a known orientation label (the Shell Column).
+func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
+	labels := []string{"OBSERVE", "TIMELINE", "LOGS", "INSPECT", "ENDPOINT", "CONCURRENCY", "PAYLOAD", "QUIT"}
+	hasLabel := func(out string) bool {
+		for _, l := range labels {
+			if contains(t, out, l) {
+				return true
+			}
+		}
+		return false
+	}
+
+	m := NewModel()
+	m.width = 100
+
+	// Idle
+	if !hasLabel(m.renderRibbon(m.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label in idle state")
+	}
+
+	// Running empty
+	m2 := NewModel()
+	m2.width = 100
+	m2.running = true
+	if !hasLabel(m2.renderRibbon(m2.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label when running empty")
+	}
+
+	// With results
+	m3 := NewModel()
+	m3.width = 100
+	m3.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if !hasLabel(m3.renderRibbon(m3.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label with results")
+	}
+
+	// Inspect mode
+	m4 := NewModel()
+	m4.width = 100
+	m4.mode = modeInspect
+	if !hasLabel(m4.renderRibbon(m4.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label in inspect mode")
+	}
+
+	// Endpoint dialog
+	m5 := NewModel()
+	m5.width = 100
+	m5.dialog = dialogEndpoint
+	if !hasLabel(m5.renderRibbon(m5.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label in endpoint dialog")
+	}
+
+	// ConfirmQuit dialog
+	m6 := NewModel()
+	m6.width = 100
+	m6.dialog = dialogConfirmQuit
+	if !hasLabel(m6.renderRibbon(m6.ShellState(), 100)) {
+		t.Fatal("ribbon must show orientation label in quit dialog")
+	}
+}
+
+// TestShellInvariant_ActionsAreIntents verifies Actions() returns behavioral
+// Action values, not presentation strings. Every Action must have a valid
+// ActionID that exists in the actionBindings table.
+func TestShellInvariant_ActionsAreIntents(t *testing.T) {
+	states := []func() []Action{
+		func() []Action { m := NewModel(); return m.Actions() },
+		func() []Action { m := NewModel(); m.running = true; return m.Actions() },
+		func() []Action { m := NewModel(); m.running = true; m.results = []model.Result{{}}; return m.Actions() },
+		func() []Action { m := NewModel(); m.results = []model.Result{{}}; return m.Actions() },
+		func() []Action { m := NewModel(); m.dialog = dialogEndpoint; return m.Actions() },
+		func() []Action { m := NewModel(); m.dialog = dialogConcurrency; return m.Actions() },
+		func() []Action { m := NewModel(); m.dialog = dialogPayload; return m.Actions() },
+		func() []Action { m := NewModel(); m.mode = modeInspect; return m.Actions() },
+		func() []Action { m := NewModel(); m.dialog = dialogConfirmQuit; return m.Actions() },
+	}
+
+	for i, actions := range states {
+		acts := actions()
+		if len(acts) == 0 {
+			t.Fatalf("state %d: Actions() must not return empty", i)
+		}
+		for _, a := range acts {
+			if _, ok := actionBindings[a.ID]; !ok {
+				t.Fatalf("state %d: Action ID %v has no binding", i, a.ID)
+			}
+			if !a.Enabled {
+				t.Fatalf("state %d: Action %v should be enabled", i, a.ID)
+			}
+		}
+	}
+}
+
+// TestShellInvariant_ViewOwnsSeparators verifies the shell (View) renders
+// separators, and they appear exactly twice (context separator, ribbon separator).
+func TestShellInvariant_ViewOwnsSeparators(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.height = 30
+	out := m.View()
+	if !contains(t, out, "─") {
+		t.Fatal("View must render shell separators")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ShellState snapshot tests
+// ---------------------------------------------------------------------------
+
+func TestShellState_ContainsOrientation(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	s := m.ShellState()
+	if s.Orientation == "" {
+		t.Fatal("ShellState.Orientation must not be empty")
+	}
+}
+
+func TestShellState_ContainsConfiguration(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	s := m.ShellState()
+	if len(s.Configuration) == 0 {
+		t.Fatal("ShellState.Configuration must not be empty")
+	}
+	foundMethod := false
+	for _, c := range s.Configuration {
+		if c.Identity == "Method" {
+			foundMethod = true
+		}
+	}
+	if !foundMethod {
+		t.Fatal("ShellState.Configuration must contain Method")
+	}
+}
+
+func TestShellState_ContainsActions(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	s := m.ShellState()
+	if len(s.Actions) == 0 {
+		t.Fatal("ShellState.Actions must not be empty")
+	}
+}
+
+func TestShellState_QueryTruncated(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.urlInput.SetValue("https://api.example.com/users?page=1")
+	s := m.ShellState()
+	url := ""
+	for _, c := range s.Configuration {
+		if c.Identity == "URL" {
+			url = c.Value
+		}
+	}
+	if !contains(t, url, "?page=1") {
+		t.Fatal("ShellState URL should retain full value (truncation is a renderer concern)")
+	}
+}
+
+func TestShellState_UpdatesWithState(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.running = true
+	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+
+	s := m.ShellState()
+	if s.Orientation != "TIMELINE" {
+		t.Fatalf("running state ShellState.Orientation = %q, want TIMELINE", s.Orientation)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Configuration model tests
+// ---------------------------------------------------------------------------
+
+func TestConfiguration_MethodAndURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	cfg := m.Configuration()
+	if len(cfg) < 3 {
+		t.Fatal("Configuration should have at least 3 items (Method, URL, CC)")
+	}
+	if cfg[0].Identity != "Method" || cfg[0].Value == "" {
+		t.Fatal("Configuration[0] should be Method with a value")
+	}
+	if cfg[1].Identity != "URL" || cfg[1].Value == "" {
+		t.Fatal("Configuration[1] should be URL with a value")
+	}
+	if cfg[2].Identity != "CC" || cfg[2].Value == "" {
+		t.Fatal("Configuration[2] should be CC with a value")
+	}
+}
+
+func TestConfiguration_InvalidURL(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.urlInput.SetValue("")
+	cfg := m.Configuration()
+	for _, c := range cfg {
+		if c.Identity == "URL" && c.Valid {
+			t.Fatal("empty URL should be marked invalid")
+		}
+	}
+}
+
+func TestConfiguration_PayloadIncluded(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	m.headers = append(m.headers, newHeaderRow())
+	m.bodyInput.SetValue("{}")
+	cfg := m.Configuration()
+	found := false
+	for _, c := range cfg {
+		if c.Identity == "Payload" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Configuration should include Payload when headers or body exist")
+	}
+}
+
+func TestConfiguration_PayloadExcluded(t *testing.T) {
+	m := NewModel()
+	m.width = 100
+	cfg := m.Configuration()
+	for _, c := range cfg {
+		if c.Identity == "Payload" {
+			t.Fatal("Configuration should NOT include Payload when empty")
 		}
 	}
 }


### PR DESCRIPTION
- Replace renderStatusBar string switch with categorized command pipeline (renderCommandBar, availableCommands, orientationLabel)
- Introduce Shell Column (fixed 16-char orientation label) + Action Column (categorized commands with within-group · and between-group gap)
- Define CommandCategory: Navigation, Configuration, Operation, Application
- Empty categories are omitted; category order is architectural
- Orientation labels: OBSERVE, TIMELINE, LOGS, INSPECT, ENDPOINT, CONCURRENCY, PAYLOAD, QUIT — structural, not mode badges
- Running does not become a label; it is execution state
- ConfirmQuit conforms: QUIT label + [Enter]/[Ctrl+C]/[q] Quit + [Any] Cancel
- All existing tests pass; add 16 shell regression tests for label pipeline, category rendering, separators, and ordering