### PR TITLE
v0.8.8: Operator Domain Consolidation

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/divijg19/Pulse/internal/stream"
 )
 
-var testClient = &http.Client{Timeout: 30 * time.Second}
-
 func TestExecuteSingle_Happy(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -21,7 +19,7 @@ func TestExecuteSingle_Happy(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	result := ExecuteSingle(context.Background(), testClient, srv.URL, "GET", nil, "")
+	result := ExecuteSingle(context.Background(), defaultClient, srv.URL, "GET", nil, "")
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -45,7 +43,7 @@ func TestExecuteSingle_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	result := ExecuteSingle(ctx, testClient, srv.URL, "GET", nil, "")
+	result := ExecuteSingle(ctx, defaultClient, srv.URL, "GET", nil, "")
 	if result.Status != 0 {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -55,7 +53,7 @@ func TestExecuteSingle_Timeout(t *testing.T) {
 }
 
 func TestExecuteSingle_Error(t *testing.T) {
-	result := ExecuteSingle(context.Background(), testClient, "http://127.0.0.1:1", "GET", nil, "")
+	result := ExecuteSingle(context.Background(), defaultClient, "http://127.0.0.1:1", "GET", nil, "")
 	if result.Status != 0 {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -81,7 +79,7 @@ func TestExecuteSingle_WithHeadersAndBody(t *testing.T) {
 	defer srv.Close()
 
 	headers := map[string]string{"X-Custom": "test-value"}
-	result := ExecuteSingle(context.Background(), testClient, srv.URL, "POST", headers, `{"key":"value"}`)
+	result := ExecuteSingle(context.Background(), defaultClient, srv.URL, "POST", headers, `{"key":"value"}`)
 	if result.Status != http.StatusOK {
 		t.Fatalf("status = %d", result.Status)
 	}
@@ -99,7 +97,7 @@ func TestExecuteSingle_RequestMethodURL_OnTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	result := ExecuteSingle(ctx, testClient, srv.URL, "POST", nil, "")
+	result := ExecuteSingle(ctx, defaultClient, srv.URL, "POST", nil, "")
 	if result.RequestMethod != "POST" {
 		t.Fatalf("RequestMethod = %q", result.RequestMethod)
 	}
@@ -109,7 +107,7 @@ func TestExecuteSingle_RequestMethodURL_OnTimeout(t *testing.T) {
 }
 
 func TestExecuteSingle_RequestMethodURL_OnConnectError(t *testing.T) {
-	result := ExecuteSingle(context.Background(), testClient, "http://127.0.0.1:1", "DELETE", nil, "")
+	result := ExecuteSingle(context.Background(), defaultClient, "http://127.0.0.1:1", "DELETE", nil, "")
 	if result.RequestMethod != "DELETE" {
 		t.Fatalf("RequestMethod = %q", result.RequestMethod)
 	}

--- a/internal/runconfig/validation_test.go
+++ b/internal/runconfig/validation_test.go
@@ -38,7 +38,7 @@ func TestValidateRejectsInvalidRequests(t *testing.T) {
 
 	for _, test := range tests {
 		if _, err := Validate(test); err == nil {
-			t.Fatalf("Validate(%+v) returned nil error", test)
+			t.Errorf("Validate(%+v) returned nil error", test)
 		}
 	}
 }

--- a/internal/tui/audit.go
+++ b/internal/tui/audit.go
@@ -29,9 +29,9 @@ func AllAuditSurfaces() []AuditSurface {
 		{"LogsRunning", newLogsRunningModel},
 		{"TimelineRunningEmpty", newTimelineRunningEmptyModel},
 		{"Inspect", newInspectModel},
-		{"Payload", newPayloadModel},
-		{"Endpoint", newEndpointModel},
-		{"Concurrency", newConcurrencyModel},
+		{"RequestPayload", newRequestPayloadModel},
+		{"Request", newRequestModel},
+		{"RequestExec", newRequestExecModel},
 		{"ConfirmQuit", newConfirmQuitModel},
 	}
 }
@@ -94,9 +94,10 @@ func newInspectModel() Model {
 	return m
 }
 
-func newPayloadModel() Model {
+func newRequestPayloadModel() Model {
 	m := NewModel()
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = bodyFocus
 	m.headers = []headerRow{newHeaderRow(), newHeaderRow()}
 	m.headers[0].Key.SetValue("Content-Type")
@@ -107,17 +108,20 @@ func newPayloadModel() Model {
 	return m
 }
 
-func newEndpointModel() Model {
+func newRequestModel() Model {
 	m := NewModel()
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.SetValue("https://httpbin.org/delay/1")
 	m.urlInput.Focus()
 	return m
 }
 
-func newConcurrencyModel() Model {
+func newRequestExecModel() Model {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.ccInput.SetValue("10")
 	m.ccInput.Focus()
 	return m

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,6 +17,14 @@ import (
 	"github.com/divijg19/Pulse/internal/stream"
 )
 
+type requestDomain int
+
+const (
+	domainRequest requestDomain = iota
+	domainPayload
+	domainExec
+)
+
 const (
 	subfocusKey      = 0
 	subfocusValue    = 1
@@ -24,8 +32,8 @@ const (
 	defaultBodyWidth = 48
 	maxTUIBodyBytes  = 1 << 20
 
-	endpointMethod = 0
-	endpointURL    = 1
+	reqFieldMethod = 0
+	reqFieldURL    = 1
 )
 
 type mode int
@@ -39,9 +47,7 @@ type dialog int
 
 const (
 	dialogNone dialog = iota
-	dialogEndpoint
-	dialogConcurrency
-	dialogPayload
+	dialogRequest
 	dialogConfirmQuit
 )
 
@@ -65,11 +71,12 @@ type Model struct {
 	dialog dialog
 	view   view
 
-	methodIndex   int
-	endpointField int
-	urlInput      textinput.Model
-	ccInput       textinput.Model
-	bodyInput     textarea.Model
+	activeDomain requestDomain
+	methodIndex  int
+	requestField int
+	urlInput     textinput.Model
+	ccInput      textinput.Model
+	bodyInput    textarea.Model
 
 	headers        []headerRow
 	selectedHead   int
@@ -119,19 +126,20 @@ func NewModel() Model {
 	body.Placeholder = `{"name":"pulse"}`
 	body.Prompt = ""
 	body.CharLimit = 1 << 20
-	body.SetHeight(5)
+	body.SetHeight(3)
 	body.SetWidth(defaultBodyWidth)
 
 	return Model{
-		mode:          modeObserve,
-		dialog:        dialogNone,
-		view:          viewTimeline,
-		methodIndex:   0,
-		endpointField: endpointURL,
-		urlInput:      url,
-		ccInput:       cc,
-		bodyInput:     body,
-		status:        "SYSTEM READY",
+		mode:         modeObserve,
+		dialog:       dialogNone,
+		view:         viewTimeline,
+		activeDomain: domainRequest,
+		methodIndex:  0,
+		requestField: reqFieldURL,
+		urlInput:     url,
+		ccInput:      cc,
+		bodyInput:    body,
+		status:       "SYSTEM READY",
 	}
 }
 
@@ -139,24 +147,25 @@ func (m Model) Init() tea.Cmd {
 	return tea.Batch(textinput.Blink, startupTimeout())
 }
 
+func (m *Model) setBodyWidths(totalWidth int) {
+	innerWidth := totalWidth - 4
+	leftWidth := max(28, innerWidth/2-2)
+	rightWidth := max(28, innerWidth-leftWidth-3)
+	m.bodyInput.SetWidth(max(10, rightWidth-6))
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		innerWidth := msg.Width - 4
-		leftWidth := max(28, innerWidth/2-2)
-		rightWidth := max(28, innerWidth-leftWidth-3)
-		m.bodyInput.SetWidth(max(10, rightWidth-6))
+		m.setBodyWidths(msg.Width)
 		return m, nil
 	case startupMsg:
 		if m.width == 0 {
 			m.width = 80
 			m.height = 24
-			innerWidth := 80 - 4
-			leftWidth := max(28, innerWidth/2-2)
-			rightWidth := max(28, innerWidth-leftWidth-3)
-			m.bodyInput.SetWidth(max(10, rightWidth-6))
+			m.setBodyWidths(80)
 		}
 		return m, nil
 	case tickMsg:
@@ -210,12 +219,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.mode {
 	case modeObserve:
 		switch m.dialog {
-		case dialogEndpoint:
-			return m.handleEndpointKey(msg)
-		case dialogConcurrency:
-			return m.handleCCKey(msg)
-		case dialogPayload:
-			return m.handlePayloadKey(msg)
+		case dialogRequest:
+			return m.handleRequestKey(msg)
 		case dialogConfirmQuit:
 			return m.handleConfirmQuitKey(msg)
 		case dialogNone:
@@ -232,142 +237,123 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	m.dialog = dialogNone
+func (m Model) handleRequestKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "ctrl+c", "q", "enter":
-		if m.running && m.cancel != nil {
-			m.cancel()
-		}
-		return m, tea.Quit
+	case "esc":
+		m.dialog = dialogNone
+		m.blurAll()
+		return m, nil
+	case "tab":
+		return m.advanceDomain(true)
+	case "shift+tab":
+		return m.advanceDomain(false)
+	case "ctrl+r":
+		return m.startRun()
+	case "ctrl+x":
+		return m.cancelRun(), nil
+	}
+
+	switch m.activeDomain {
+	case domainRequest:
+		return m.handleRequestDomainKey(msg)
+	case domainPayload:
+		return m.handlePayloadDomainKey(msg)
+	case domainExec:
+		return m.handleExecDomainKey(msg)
 	}
 	return m, nil
 }
 
-func (m Model) handleEndpointKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+func (m Model) advanceDomain(forward bool) (tea.Model, tea.Cmd) {
+	if forward {
+		switch m.activeDomain {
+		case domainRequest:
+			if m.requestField == reqFieldURL {
+				m.activeDomain = domainPayload
+				m.selectedHead = 0
+				m.headerSubfocus = subfocusKey
+				if len(m.headers) == 0 {
+					m.headers = append(m.headers, newHeaderRow())
+				}
+				m.focusPayloadKey()
+			} else {
+				m.requestField = reqFieldURL
+				m.urlInput.Focus()
+			}
+		case domainPayload:
+			if m.selectedHead == bodyFocus {
+				m.activeDomain = domainExec
+				m.ccInput.Focus()
+			} else {
+				m.selectedHead = bodyFocus
+				m.focusPayloadBody()
+			}
+		case domainExec:
+			m.activeDomain = domainRequest
+			m.requestField = reqFieldMethod
+			m.blurAll()
+		}
+	} else {
+		switch m.activeDomain {
+		case domainRequest:
+			if m.requestField == reqFieldMethod {
+				m.activeDomain = domainExec
+				m.ccInput.Focus()
+			} else {
+				m.requestField = reqFieldMethod
+				m.blurAll()
+			}
+		case domainPayload:
+			if m.selectedHead == bodyFocus {
+				if len(m.headers) == 0 {
+					m.headers = append(m.headers, newHeaderRow())
+				}
+				m.selectedHead = 0
+				m.headerSubfocus = subfocusKey
+				m.focusPayloadKey()
+			} else {
+				m.activeDomain = domainRequest
+				m.requestField = reqFieldURL
+				m.urlInput.Focus()
+			}
+		case domainExec:
+			m.activeDomain = domainPayload
+			m.selectedHead = bodyFocus
+			m.focusPayloadBody()
+		}
+	}
+	return m, nil
+}
+
+func (m Model) handleRequestDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "esc":
-		m.dialog = dialogNone
-		m.urlInput.Blur()
-		return m, nil
-	case "tab":
-		m.endpointField = (m.endpointField + 1) % 2
-		if m.endpointField == endpointURL {
-			m.urlInput.Focus()
-		} else {
-			m.urlInput.Blur()
-		}
-		return m, nil
-	case "shift+tab":
-		m.endpointField = (m.endpointField + 1) % 2
-		if m.endpointField == endpointURL {
-			m.urlInput.Focus()
-		} else {
-			m.urlInput.Blur()
-		}
-		return m, nil
 	case "left", "h":
-		if m.endpointField == endpointMethod && m.methodIndex > 0 {
+		if m.requestField == reqFieldMethod && m.methodIndex > 0 {
 			m.methodIndex--
 		}
-		if m.endpointField != endpointMethod {
+		if m.requestField != reqFieldMethod {
 			break
 		}
 		return m, nil
 	case "right", "l":
-		if m.endpointField == endpointMethod {
+		if m.requestField == reqFieldMethod {
 			methods := runconfig.AllowedMethods()
 			if m.methodIndex < len(methods)-1 {
 				m.methodIndex++
 			}
 		}
-		if m.endpointField != endpointMethod {
+		if m.requestField != reqFieldMethod {
 			break
 		}
 		return m, nil
-	case "ctrl+r":
-		return m.startRun()
-	case "ctrl+x":
-		return m.cancelRun(), nil
 	}
 	var cmd tea.Cmd
 	m.urlInput, cmd = m.urlInput.Update(msg)
 	return m, cmd
 }
 
-func (m Model) handleCCKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		m.dialog = dialogNone
-		m.ccInput.Blur()
-		return m, nil
-	case "up", "k":
-		m.setConcurrency(m.concurrency() + 1)
-		return m, nil
-	case "down", "j":
-		m.setConcurrency(m.concurrency() - 1)
-		return m, nil
-	case "ctrl+r":
-		return m.startRun()
-	case "ctrl+x":
-		return m.cancelRun(), nil
-	}
-	var cmd tea.Cmd
-	m.ccInput, cmd = m.ccInput.Update(msg)
-	return m, cmd
-}
-
-func (m *Model) blurAll() {
-	m.urlInput.Blur()
-	m.ccInput.Blur()
-	m.bodyInput.Blur()
-	for i := range m.headers {
-		m.headers[i].Key.Blur()
-		m.headers[i].Value.Blur()
-	}
-}
-
-func (m *Model) focusPayloadKey() {
-	m.blurAll()
-	m.headers[m.selectedHead].Key.Focus()
-}
-
-func (m *Model) focusPayloadValue() {
-	m.blurAll()
-	m.headers[m.selectedHead].Value.Focus()
-}
-
-func (m *Model) focusPayloadBody() {
-	m.blurAll()
-	m.bodyInput.Focus()
-}
-
-func (m Model) handlePayloadKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		m.dialog = dialogNone
-		m.blurAll()
-		return m, nil
-	case "ctrl+r":
-		return m.startRun()
-	case "ctrl+x":
-		return m.cancelRun(), nil
-	}
-
+func (m Model) handlePayloadDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.selectedHead == bodyFocus {
-		switch msg.String() {
-		case "tab":
-			m.selectedHead = 0
-			if len(m.headers) == 0 {
-				m.headers = append(m.headers, newHeaderRow())
-			}
-			if m.headerSubfocus == subfocusKey {
-				m.focusPayloadKey()
-			} else {
-				m.focusPayloadValue()
-			}
-			return m, nil
-		}
 		var cmd tea.Cmd
 		m.bodyInput, cmd = m.bodyInput.Update(msg)
 		return m, cmd
@@ -413,10 +399,6 @@ func (m Model) handlePayloadKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.headerSubfocus = subfocusValue
 		m.focusPayloadValue()
 		return m, nil
-	case "tab":
-		m.selectedHead = bodyFocus
-		m.focusPayloadBody()
-		return m, nil
 	default:
 		if m.selectedHead >= 0 && m.selectedHead < len(m.headers) {
 			var cmd tea.Cmd
@@ -430,6 +412,57 @@ func (m Model) handlePayloadKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m Model) handleExecDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		m.setConcurrency(m.concurrency() + 1)
+		return m, nil
+	case "down", "j":
+		m.setConcurrency(m.concurrency() - 1)
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.ccInput, cmd = m.ccInput.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handleConfirmQuitKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.dialog = dialogNone
+	switch msg.String() {
+	case "ctrl+c", "q", "enter":
+		if m.running && m.cancel != nil {
+			m.cancel()
+		}
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *Model) blurAll() {
+	m.urlInput.Blur()
+	m.ccInput.Blur()
+	m.bodyInput.Blur()
+	for i := range m.headers {
+		m.headers[i].Key.Blur()
+		m.headers[i].Value.Blur()
+	}
+}
+
+func (m *Model) focusPayloadKey() {
+	m.blurAll()
+	m.headers[m.selectedHead].Key.Focus()
+}
+
+func (m *Model) focusPayloadValue() {
+	m.blurAll()
+	m.headers[m.selectedHead].Value.Focus()
+}
+
+func (m *Model) focusPayloadBody() {
+	m.blurAll()
+	m.bodyInput.Focus()
 }
 
 func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -468,22 +501,11 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.view = viewLogs
 		return m, nil
 	case "e":
-		m.dialog = dialogEndpoint
-		m.endpointField = endpointURL
+		m.dialog = dialogRequest
+		m.blurAll()
+		m.activeDomain = domainRequest
+		m.requestField = reqFieldURL
 		m.urlInput.Focus()
-		return m, nil
-	case "c":
-		m.dialog = dialogConcurrency
-		m.ccInput.Focus()
-		return m, nil
-	case "p":
-		m.dialog = dialogPayload
-		m.selectedHead = 0
-		m.headerSubfocus = subfocusKey
-		if len(m.headers) == 0 {
-			m.headers = append(m.headers, newHeaderRow())
-		}
-		m.focusPayloadKey()
 		return m, nil
 	case "ctrl+r":
 		return m.startRun()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -14,14 +14,19 @@ import (
 
 func TestMethodSelection(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
-	// pressing Tab should not crash (Tab is a no-op in endpoint dialog currently)
+	// Tab advances from URL field to Payload domain (stays within request dialog)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.dialog != dialogEndpoint {
-		t.Fatal("tab should not close endpoint dialog")
+	if m.dialog != dialogRequest {
+		t.Fatal("tab should not close request dialog")
+	}
+	if m.activeDomain != domainPayload {
+		t.Fatal("tab from URL field should advance to payload domain")
 	}
 }
 
@@ -39,12 +44,16 @@ func TestConcurrencyClamping(t *testing.T) {
 
 func TestPayloadEditorState(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 
-	if m.dialog != dialogPayload {
-		t.Fatal("payload dialog should be active")
+	if m.dialog != dialogRequest {
+		t.Fatal("request dialog should be active")
+	}
+	if m.activeDomain != domainPayload {
+		t.Fatal("payload domain should be active")
 	}
 	if len(m.headers) != 0 {
 		t.Fatalf("headers len = %d (expect 0, lazily initialized)", len(m.headers))
@@ -146,7 +155,8 @@ func TestResultSelectionAndInspect(t *testing.T) {
 
 func TestHeaderAddRemove(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
@@ -593,55 +603,70 @@ func TestObserve_EndpointDialogOpenClose(t *testing.T) {
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
 	m = updated.(Model)
-	if m.dialog != dialogEndpoint {
-		t.Fatal("pressing e should open endpoint dialog")
+	if m.dialog != dialogRequest {
+		t.Fatal("pressing e should open request dialog")
+	}
+	if m.activeDomain != domainRequest {
+		t.Fatal("pressing e should set active domain to request")
 	}
 
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
 	if m.dialog != dialogNone {
-		t.Fatal("pressing esc should close endpoint dialog")
+		t.Fatal("pressing esc should close request dialog")
 	}
 }
 
 func TestObserve_CCDialogOpenClose(t *testing.T) {
 	m := NewModel()
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
+	m.ccInput.Focus()
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
-	m = updated.(Model)
-	if m.dialog != dialogConcurrency {
-		t.Fatal("pressing c should open concurrency dialog")
+	if m.dialog != dialogRequest {
+		t.Fatal("request dialog should be active")
+	}
+	if m.activeDomain != domainExec {
+		t.Fatal("execution domain should be active")
 	}
 
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	// Esc closes the request dialog
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
 	if m.dialog != dialogNone {
-		t.Fatal("pressing esc should close concurrency dialog")
+		t.Fatal("pressing esc should close request dialog")
 	}
 }
 
 func TestObserve_PayloadDialogOpenClose(t *testing.T) {
 	m := NewModel()
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
+	m.selectedHead = 0
+	m.headerSubfocus = subfocusKey
 
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
-	m = updated.(Model)
-	if m.dialog != dialogPayload {
-		t.Fatal("pressing p should open payload dialog")
+	if m.dialog != dialogRequest {
+		t.Fatal("request dialog should be active")
 	}
-	if len(m.headers) == 0 {
-		t.Fatal("opening payload dialog should initialize headers")
+	if m.activeDomain != domainPayload {
+		t.Fatal("payload domain should be active")
+	}
+	if len(m.headers) != 0 {
+		t.Fatal("headers should be lazily initialized")
 	}
 
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	// Esc closes the request dialog
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
 	if m.dialog != dialogNone {
-		t.Fatal("pressing esc should close payload dialog")
+		t.Fatal("pressing esc should close request dialog")
 	}
 }
 
 func TestCCDialog_ArrowAdjustUp(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 
 	initial := m.concurrency()
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -654,7 +679,8 @@ func TestCCDialog_ArrowAdjustUp(t *testing.T) {
 
 func TestCCDialog_ArrowAdjustDown(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.setConcurrency(50)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
@@ -667,32 +693,37 @@ func TestCCDialog_ArrowAdjustDown(t *testing.T) {
 
 func TestEndpointDialog_EscCloses(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
 	if m.dialog != dialogNone {
-		t.Fatal("esc should close endpoint dialog")
+		t.Fatal("esc should close request dialog")
 	}
 }
 
 func TestEndpointDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(Model)
-	if m.dialog != dialogEndpoint {
-		t.Fatal("enter should NOT close endpoint dialog (esc-only)")
+	if m.dialog != dialogRequest {
+		t.Fatal("enter should NOT close request dialog (esc-only)")
 	}
 }
 
 func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
-	m.endpointField = endpointMethod
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldMethod
 
 	methods := runconfig.AllowedMethods()
 
@@ -702,21 +733,21 @@ func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 	}
 
 	// Right arrow increments
-	updated, _ := m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ := m.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyRight})
 	m = updated.(Model)
 	if m.methodIndex != 1 {
 		t.Errorf("after right, methodIndex = %d, want 1", m.methodIndex)
 	}
 
 	// Left arrow decrements
-	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyLeft})
+	updated, _ = m.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyLeft})
 	m = updated.(Model)
 	if m.methodIndex != 0 {
 		t.Errorf("after left, methodIndex = %d, want 0", m.methodIndex)
 	}
 
 	// Left at min does not go below 0
-	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyLeft})
+	updated, _ = m.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyLeft})
 	m = updated.(Model)
 	if m.methodIndex != 0 {
 		t.Errorf("left at min should stay 0, got %d", m.methodIndex)
@@ -724,7 +755,7 @@ func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 
 	// Right at max does not exceed
 	m.methodIndex = len(methods) - 1
-	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ = m.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyRight})
 	m = updated.(Model)
 	if m.methodIndex != len(methods)-1 {
 		t.Errorf("right at max should stay %d, got %d", len(methods)-1, m.methodIndex)
@@ -733,29 +764,24 @@ func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 
 func TestEndpointDialog_TabSwitchesField(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
-	m.endpointField = endpointURL
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
-	// Tab should switch to method
-	updated, _ := m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyTab})
+	// Tab should advance to payload domain (URL → Payload)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.endpointField != endpointMethod {
-		t.Fatal("tab should switch to method field")
-	}
-
-	// Tab again back to URL
-	updated, _ = m.handleEndpointKey(tea.KeyMsg{Type: tea.KeyTab})
-	m = updated.(Model)
-	if m.endpointField != endpointURL {
-		t.Fatal("second tab should switch back to URL field")
+	if m.activeDomain != domainPayload {
+		t.Fatal("tab from URL field should advance to payload domain")
 	}
 }
 
 func TestEndpointDialog_LeftRightOnUrlDoesNotChangeMethod(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
-	m.endpointField = endpointURL
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
 	initialMethod := m.methodIndex
@@ -776,25 +802,27 @@ func TestEndpointDialog_LeftRightOnUrlDoesNotChangeMethod(t *testing.T) {
 
 func TestCCDialog_EscCloses(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = updated.(Model)
 	if m.dialog != dialogNone {
-		t.Fatal("esc should close concurrency dialog")
+		t.Fatal("esc should close request dialog")
 	}
 }
 
 func TestCCDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = updated.(Model)
-	if m.dialog != dialogConcurrency {
-		t.Fatal("enter should NOT close concurrency dialog (esc-only)")
+	if m.dialog != dialogRequest {
+		t.Fatal("enter should NOT close request dialog (esc-only)")
 	}
 }
 
@@ -849,14 +877,16 @@ func TestViewSwitch_PreservesSelection(t *testing.T) {
 
 func TestEndpointDialog_NotClosableByWrongKey(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
 	// Typing text should go to urlInput, not close dialog
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 	m = updated.(Model)
-	if m.dialog != dialogEndpoint {
-		t.Fatal("typing text should not close endpoint dialog")
+	if m.dialog != dialogRequest {
+		t.Fatal("typing text should not close request dialog")
 	}
 	if !strings.Contains(m.urlInput.Value(), "/") {
 		t.Fatal("URL input should contain typed character")
@@ -865,7 +895,8 @@ func TestEndpointDialog_NotClosableByWrongKey(t *testing.T) {
 
 func TestCCDialog_TypesDigits(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -878,7 +909,8 @@ func TestCCDialog_TypesDigits(t *testing.T) {
 
 func TestPayloadDialog_HeaderNavigationUpDown(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow(), newHeaderRow())
@@ -912,28 +944,31 @@ func TestPayloadDialog_HeaderNavigationUpDown(t *testing.T) {
 
 func TestPayloadDialog_TabToBody(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
 
+	// Tab within payload: headers → body
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
 	if m.selectedHead != bodyFocus {
 		t.Fatalf("tab from headers should go to body, got selectedHead=%d", m.selectedHead)
 	}
 
+	// Tab from body → next domain (execution)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.selectedHead != 0 {
-		t.Fatalf("tab from body should go to headers, got selectedHead=%d", m.selectedHead)
+	if m.activeDomain != domainExec {
+		t.Fatalf("tab from body should advance to execution domain, got domain=%d", m.activeDomain)
 	}
 }
 
 func TestStartRun_ResetsDialogAndMode(t *testing.T) {
 	m := NewModel()
 	m.mode = modeInspect
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
 	m.urlInput.SetValue("https://example.com/api")
 	m.setConcurrency(1)
 
@@ -987,7 +1022,8 @@ func TestConfirmQuit_FromInspectMode(t *testing.T) {
 
 func TestCCDialog_ClampAtMax(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.setConcurrency(100)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -999,7 +1035,8 @@ func TestCCDialog_ClampAtMax(t *testing.T) {
 
 func TestCCDialog_ClampAtMin(t *testing.T) {
 	m := NewModel()
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.setConcurrency(1)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,12 +14,11 @@ const (
 )
 
 var (
-	styleBase       = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
-	styleTopBar     = styleBase.Copy().Bold(true)
-	styleRibbon     = styleBase.Copy().Background(lipgloss.Color(colorDark))
-	styleStatusMode = lipgloss.NewStyle().Background(lipgloss.Color(colorAccent)).Foreground(lipgloss.Color(colorBg)).Bold(true)
-	styleSeparator  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
-	styleMuted      = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	styleBase      = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
+	styleTopBar    = styleBase.Copy().Bold(true)
+	styleRibbon    = styleBase.Copy().Background(lipgloss.Color(colorDark))
+	styleSeparator = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	styleMuted     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 )
 
 func statusColor(status int) string {

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -36,8 +36,8 @@ func TestStyleBase(t *testing.T) {
 	if got := styleBase.GetBackground(); got != lipgloss.Color(colorBg) {
 		t.Errorf("styleBase background = %q, want %q", got, colorBg)
 	}
-	if got := styleBase.GetBackground(); got != lipgloss.Color(colorBg) {
-		t.Errorf("styleBase background = %q, want %q", got, colorBg)
+	if got := styleBase.GetForeground(); got != lipgloss.Color(colorText) {
+		t.Errorf("styleBase foreground = %q, want %q", got, colorText)
 	}
 }
 
@@ -47,24 +47,6 @@ func TestStyleRibbon(t *testing.T) {
 	}
 	if got := styleRibbon.GetBackground(); got != lipgloss.Color(colorDark) {
 		t.Errorf("styleRibbon background = %q, want %q", got, colorDark)
-	}
-}
-
-func TestStyleStatusMode(t *testing.T) {
-	if got := styleStatusMode.GetForeground(); got != lipgloss.Color(colorBg) {
-		t.Errorf("styleStatusMode foreground = %q, want %q", got, colorBg)
-	}
-	if got := styleStatusMode.GetBackground(); got != lipgloss.Color(colorAccent) {
-		t.Errorf("styleStatusMode background = %q, want %q", got, colorAccent)
-	}
-	if got := styleStatusMode.GetBold(); !got {
-		t.Error("styleStatusMode should be bold")
-	}
-	if got := styleStatusMode.GetBackground(); got != lipgloss.Color(colorAccent) {
-		t.Errorf("styleStatusMode background = %q, want %q", got, colorAccent)
-	}
-	if got := styleStatusMode.GetBold(); !got {
-		t.Error("styleStatusMode should be bold")
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -56,9 +56,7 @@ const (
 	ActionSelect ActionID = iota
 	ActionInspect
 	ActionSwitchView
-	ActionConfigureEndpoint
-	ActionConfigureConcurrency
-	ActionConfigurePayload
+	ActionConfigureRequest
 	ActionRun
 	ActionCancel
 	ActionNextField
@@ -110,46 +108,36 @@ type actionBinding struct {
 }
 
 var actionBindings = map[ActionID]actionBinding{
-	ActionSelect:               {"↑↓", "Select", NavigationCategory},
-	ActionInspect:              {"Enter", "Inspect", NavigationCategory},
-	ActionSwitchView:           {"Tab", "Views", NavigationCategory},
-	ActionConfigureEndpoint:    {"e", "Endpoint", ConfigurationCategory},
-	ActionConfigureConcurrency: {"c", "Concurrency", ConfigurationCategory},
-	ActionConfigurePayload:     {"p", "Payload", ConfigurationCategory},
-	ActionRun:                  {"Ctrl+R", "Run", OperationCategory},
-	ActionCancel:               {"Ctrl+X", "Cancel", OperationCategory},
-	ActionNextField:            {"Tab", "Next Field", ConfigurationCategory},
-	ActionSwitchMethod:         {"←→", "Method", ConfigurationCategory},
-	ActionAdjustConcurrency:    {"↑↓", "Adjust", ConfigurationCategory},
-	ActionNextHeader:           {"Tab", "Next", ConfigurationCategory},
-	ActionAddHeader:            {"Ctrl+N", "Header", ConfigurationCategory},
-	ActionDeleteHeader:         {"Ctrl+D", "Delete", ConfigurationCategory},
-	ActionBack:                 {"Esc", "Back", ApplicationCategory},
-	ActionQuit:                 {"q", "Quit", ApplicationCategory},
-	ActionConfirmQuit:          {"Enter", "Quit", ApplicationCategory},
-	ActionCtrlCQuit:            {"Ctrl+C", "Quit", ApplicationCategory},
-	ActionQQuit:                {"q", "Quit", ApplicationCategory},
-	ActionDismissCancel:        {"Any", "Cancel", ApplicationCategory},
+	ActionSelect:            {"↑↓", "Select", NavigationCategory},
+	ActionInspect:           {"Enter", "Inspect", NavigationCategory},
+	ActionSwitchView:        {"Tab", "Views", NavigationCategory},
+	ActionConfigureRequest:  {"e", "Request", ConfigurationCategory},
+	ActionRun:               {"Ctrl+R", "Run", OperationCategory},
+	ActionCancel:            {"Ctrl+X", "Cancel", OperationCategory},
+	ActionNextField:         {"Tab", "Next Field", ConfigurationCategory},
+	ActionSwitchMethod:      {"←→", "Method", ConfigurationCategory},
+	ActionAdjustConcurrency: {"↑↓", "Adjust", ConfigurationCategory},
+	ActionNextHeader:        {"Tab", "Next", ConfigurationCategory},
+	ActionAddHeader:         {"Ctrl+N", "Header", ConfigurationCategory},
+	ActionDeleteHeader:      {"Ctrl+D", "Delete", ConfigurationCategory},
+	ActionBack:              {"Esc", "Back", ApplicationCategory},
+	ActionQuit:              {"q", "Quit", ApplicationCategory},
+	ActionConfirmQuit:       {"Enter", "Quit", ApplicationCategory},
+	ActionCtrlCQuit:         {"Ctrl+C", "Quit", ApplicationCategory},
+	ActionQQuit:             {"q", "Quit", ApplicationCategory},
+	ActionDismissCancel:     {"Any", "Cancel", ApplicationCategory},
 }
 
 func (m Model) orientationLabel() string {
 	switch {
 	case m.dialog == dialogConfirmQuit:
 		return "QUIT"
-	case m.dialog == dialogEndpoint:
-		return "ENDPOINT"
-	case m.dialog == dialogConcurrency:
-		return "CONCURRENCY"
-	case m.dialog == dialogPayload:
-		return "PAYLOAD"
+	case m.dialog == dialogRequest:
+		return "REQUEST"
 	case m.mode == modeInspect:
 		return "INSPECT"
-	case !m.running && len(m.results) == 0:
-		return "OBSERVE"
-	case m.view == viewTimeline:
-		return "TIMELINE"
 	default:
-		return "LOGS"
+		return "OBSERVE"
 	}
 }
 
@@ -162,24 +150,8 @@ func (m Model) Actions() []Action {
 			{ActionQQuit, ApplicationCategory, true},
 			{ActionDismissCancel, ApplicationCategory, true},
 		}
-	case m.dialog == dialogEndpoint:
-		return []Action{
-			{ActionNextField, ConfigurationCategory, true},
-			{ActionSwitchMethod, ConfigurationCategory, true},
-			{ActionBack, ApplicationCategory, true},
-		}
-	case m.dialog == dialogConcurrency:
-		return []Action{
-			{ActionAdjustConcurrency, ConfigurationCategory, true},
-			{ActionBack, ApplicationCategory, true},
-		}
-	case m.dialog == dialogPayload:
-		return []Action{
-			{ActionNextHeader, ConfigurationCategory, true},
-			{ActionAddHeader, ConfigurationCategory, true},
-			{ActionDeleteHeader, ConfigurationCategory, true},
-			{ActionBack, ApplicationCategory, true},
-		}
+	case m.dialog == dialogRequest:
+		return m.requestActions()
 	case m.mode == modeInspect:
 		return []Action{
 			{ActionSelect, NavigationCategory, true},
@@ -199,9 +171,7 @@ func (m Model) Actions() []Action {
 		}
 	case !m.running && len(m.results) == 0:
 		return []Action{
-			{ActionConfigureEndpoint, ConfigurationCategory, true},
-			{ActionConfigureConcurrency, ConfigurationCategory, true},
-			{ActionConfigurePayload, ConfigurationCategory, true},
+			{ActionConfigureRequest, ConfigurationCategory, true},
 			{ActionRun, OperationCategory, true},
 			{ActionQuit, ApplicationCategory, true},
 		}
@@ -210,13 +180,36 @@ func (m Model) Actions() []Action {
 			{ActionSelect, NavigationCategory, true},
 			{ActionInspect, NavigationCategory, true},
 			{ActionSwitchView, NavigationCategory, true},
-			{ActionConfigureEndpoint, ConfigurationCategory, true},
-			{ActionConfigureConcurrency, ConfigurationCategory, true},
-			{ActionConfigurePayload, ConfigurationCategory, true},
+			{ActionConfigureRequest, ConfigurationCategory, true},
 			{ActionRun, OperationCategory, true},
 			{ActionQuit, ApplicationCategory, true},
 		}
 	}
+}
+
+func (m Model) requestActions() []Action {
+	domainActions := []Action{
+		{ActionBack, ApplicationCategory, true},
+		{ActionRun, OperationCategory, true},
+	}
+	switch m.activeDomain {
+	case domainRequest:
+		domainActions = append([]Action{
+			{ActionNextField, ConfigurationCategory, true},
+			{ActionSwitchMethod, ConfigurationCategory, true},
+		}, domainActions...)
+	case domainPayload:
+		domainActions = append([]Action{
+			{ActionNextField, ConfigurationCategory, true},
+			{ActionAddHeader, ConfigurationCategory, true},
+			{ActionDeleteHeader, ConfigurationCategory, true},
+		}, domainActions...)
+	case domainExec:
+		domainActions = append([]Action{
+			{ActionAdjustConcurrency, ConfigurationCategory, true},
+		}, domainActions...)
+	}
+	return domainActions
 }
 
 func (m Model) Configuration() []configItem {
@@ -264,12 +257,8 @@ func (m Model) View() string {
 
 func (m Model) renderCurrentSurface(region Region) string {
 	switch {
-	case m.dialog == dialogPayload:
-		return m.renderPayload(region)
-	case m.dialog == dialogEndpoint:
-		return m.renderEndpoint(region)
-	case m.dialog == dialogConcurrency:
-		return m.renderConcurrency(region)
+	case m.dialog == dialogRequest:
+		return m.renderRequest(region)
 	case m.mode == modeInspect:
 		return m.renderInspect(region)
 	case !m.running && len(m.results) == 0:
@@ -369,16 +358,27 @@ func (m Model) renderReady(region Region) string {
 	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
 
-func (m Model) renderEndpoint(region Region) string {
-	var b strings.Builder
-	b.WriteString(identityCell("Endpoint", true))
+func isErrorResult(result model.Result) bool {
+	return result.Status >= 400 || result.Status == 0
+}
+
+func accentOrMuted(name string, active bool) string {
+	if active {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render(name)
+	}
+	return styleMuted.Render(name)
+}
+
+func (m Model) renderRequestDomain(b *strings.Builder) {
+	b.WriteString("\n")
+	b.WriteString(accentOrMuted("Request", m.activeDomain == domainRequest))
 	b.WriteString("\n")
 
 	methods := runconfig.AllowedMethods()
 	var methodLine string
 	for i, method := range methods {
 		sel := i == m.methodIndex
-		focus := m.endpointField == endpointMethod
+		focus := m.activeDomain == domainRequest && m.requestField == reqFieldMethod
 		if sel && focus {
 			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Background(lipgloss.Color(colorDark)).Render(" " + method + " ")
 		} else if sel {
@@ -389,78 +389,81 @@ func (m Model) renderEndpoint(region Region) string {
 	}
 
 	methodLabel := "Method"
-	if m.endpointField == endpointMethod {
+	if m.activeDomain == domainRequest && m.requestField == reqFieldMethod {
 		methodLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("Method")
 	} else {
 		methodLabel = styleMuted.Render("Method")
 	}
 
-	b.WriteString(fmt.Sprintf(
-		"\n%s\n  %s\n%s\n  %s",
-		methodLabel,
-		methodLine,
-		styleMuted.Render("URL"),
-		m.urlInput.View(),
-	))
+	b.WriteString(fmt.Sprintf("  %s\n    %s\n", methodLabel, methodLine))
 
-	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
-}
-
-func (m Model) renderConcurrency(region Region) string {
-	var b strings.Builder
-	b.WriteString(identityCell("Concurrency", true))
-	b.WriteString("\n\n")
-
-	ccText := strings.TrimSpace(m.ccInput.View())
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Bold(true).Render(
-		fmt.Sprintf("  %s  (1–%d)", ccText, runconfig.MaxConcurrency),
-	))
-
-	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
-}
-
-func (m Model) renderPayload(region Region) string {
-	var b strings.Builder
-	b.WriteString(identityCell("Payload", true))
-	b.WriteString("\n")
-
-	headersColor := colorMuted
-	if m.selectedHead != bodyFocus {
-		headersColor = colorAccent
+	urlLabel := "URL"
+	if m.activeDomain == domainRequest && m.requestField == reqFieldURL {
+		urlLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("URL")
+	} else {
+		urlLabel = styleMuted.Render("URL")
 	}
+	b.WriteString(fmt.Sprintf("  %s\n    %s\n", urlLabel, m.urlInput.View()))
+}
+
+func (m Model) renderPayloadDomain(b *strings.Builder) {
 	b.WriteString("\n")
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(headersColor)).Render("HEADERS  ctrl+n add  ctrl+d remove"))
+	b.WriteString(accentOrMuted("Payload", m.activeDomain == domainPayload))
+	b.WriteString("\n")
+
+	headersActive := m.activeDomain == domainPayload && m.selectedHead != bodyFocus
+	b.WriteString(accentOrMuted("  HEADERS  ctrl+n add  ctrl+d remove", headersActive))
 	b.WriteString("\n")
 
 	if len(m.headers) == 0 {
-		b.WriteString(styleMuted.Render("  No headers configured."))
+		b.WriteString(styleMuted.Render("    No headers configured."))
 	} else {
 		for i, header := range m.headers {
 			key := header.Key.View()
 			value := header.Value.View()
 			sel := i == m.selectedHead
 			cursor := rowCursor(sel)
-			line := fmt.Sprintf("%s %s: %s", cursor, key, value)
+			line := fmt.Sprintf("  %s %s: %s", cursor, key, value)
 			b.WriteString(rowStyle(sel).Render(line))
 			b.WriteString("\n")
 		}
 	}
 
-	b.WriteString("\n")
-
-	bodyColor := colorMuted
-	if m.selectedHead == bodyFocus {
-		bodyColor = colorAccent
-	}
+	bodyActive := m.activeDomain == domainPayload && m.selectedHead == bodyFocus
 	bodyLen := len(m.bodyInput.Value())
-	bodyLabel := "BODY"
+	bodyLabel := "  BODY"
 	if bodyLen > 0 {
-		bodyLabel = fmt.Sprintf("BODY (%d KB / %d KB)", bodyLen/1024, maxTUIBodyBytes/1024)
+		bodyLabel = fmt.Sprintf("  BODY (%d KB / %d KB)", bodyLen/1024, maxTUIBodyBytes/1024)
 	}
-	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(bodyColor)).Render(bodyLabel))
+	b.WriteString(accentOrMuted(bodyLabel, bodyActive))
+	b.WriteString("\n")
+	b.WriteString("  " + m.bodyInput.View())
+}
+
+func (m Model) renderExecDomain(b *strings.Builder) {
+	b.WriteString("\n")
+	b.WriteString(accentOrMuted("Execution", m.activeDomain == domainExec))
 	b.WriteString("\n")
 
-	b.WriteString(m.bodyInput.View())
+	ccText := strings.TrimSpace(m.ccInput.View())
+	active := m.activeDomain == domainExec
+	ccLabel := accentOrMuted("  Concurrency", active)
+	if active {
+		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccText, runconfig.MaxConcurrency))
+	} else {
+		ccVal := lipgloss.NewStyle().Foreground(lipgloss.Color(colorText)).Render(ccText)
+		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccVal, runconfig.MaxConcurrency))
+	}
+}
+
+func (m Model) renderRequest(region Region) string {
+	var b strings.Builder
+	b.WriteString(identityCell("REQUEST", false))
+	b.WriteString("\n")
+
+	m.renderRequestDomain(&b)
+	m.renderPayloadDomain(&b)
+	m.renderExecDomain(&b)
 
 	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
 }
@@ -496,8 +499,9 @@ func (m Model) renderRibbon(state ShellState, width int) string {
 
 	actionColumn := strings.Join(actionParts, "    ")
 
+	anchor := lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("│")
 	var ribbonParts []string
-	ribbonParts = append(ribbonParts, fmt.Sprintf("%-*s", ShellColumnWidth, label))
+	ribbonParts = append(ribbonParts, fmt.Sprintf("%s %-*s", anchor, ShellColumnWidth-2, label))
 	if actionColumn != "" {
 		ribbonParts = append(ribbonParts, actionColumn)
 	}
@@ -592,7 +596,7 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	line := fmt.Sprintf("%s %3d %-4s %-12s %s %s",
 		rowCursor(selected), index+1, method, status, bar, latency)
 
-	if result.Status >= 400 || result.Status == 0 {
+	if isErrorResult(result) {
 		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
 	}
 	return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
@@ -612,7 +616,7 @@ func (m Model) renderLogs(region Region) string {
 			}
 			line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
 				rowCursor(selected), index+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
-			if result.Status >= 400 || result.Status == 0 {
+			if isErrorResult(result) {
 				return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
 			}
 			return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -83,7 +83,7 @@ func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out = m.View()
-	if contains(t, out, "OBSERVE") {
+	if contains(t, out, "▶  Ready") {
 		t.Fatal("after results exist, Ready should not appear")
 	}
 }
@@ -272,14 +272,8 @@ func TestRenderRibbon_Ready(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderRibbon(m.ShellState(), 100)
-	if !contains(t, out, "[e] Endpoint") {
-		t.Fatal("ready ribbon should show [e] Endpoint")
-	}
-	if !contains(t, out, "[c] Concurrency") {
-		t.Fatal("ready ribbon should show [c] Concurrency")
-	}
-	if !contains(t, out, "[p] Payload") {
-		t.Fatal("ready ribbon should show [p] Payload")
+	if !contains(t, out, "[e] Request") {
+		t.Fatal("ready ribbon should show [e] Request")
 	}
 	if contains(t, out, "[↑↓]") {
 		t.Fatal("ready ribbon should not advertise [↑↓] (inert)")
@@ -331,32 +325,34 @@ func TestRenderRibbon_RunningWithResults(t *testing.T) {
 	}
 }
 
-func TestRenderRibbon_EndpointDialog(t *testing.T) {
+func TestRenderRibbon_RequestDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("endpoint ribbon should show [Esc] Back")
+		t.Fatal("request ribbon should show [Esc] Back")
 	}
 	if !contains(t, out, "[Tab] Next Field") {
-		t.Fatal("endpoint ribbon should show [Tab] Next Field")
+		t.Fatal("request ribbon should show [Tab] Next Field")
 	}
 	if !contains(t, out, "[←→] Method") {
-		t.Fatal("endpoint ribbon should show [←→] Method")
+		t.Fatal("request ribbon should show [←→] Method")
 	}
 }
 
-func TestRenderRibbon_CCDialog(t *testing.T) {
+func TestRenderRibbon_RequestExecDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("concurrency ribbon should show [Esc] Back")
+		t.Fatal("request exec ribbon should show [Esc] Back")
 	}
 	if !contains(t, out, "[↑↓] Adjust") {
-		t.Fatal("concurrency ribbon should show [↑↓] Adjust")
+		t.Fatal("request exec ribbon should show [↑↓] Adjust")
 	}
 }
 
@@ -823,56 +819,59 @@ func TestView_PayloadNotShown(t *testing.T) {
 func TestRenderPayload_Identity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
-	if !contains(t, out, "Payload") {
-		t.Fatal("payload should show identity header")
+	out := m.renderRequest(Region{Width: 96, Height: 20})
+	if !contains(t, out, "REQUEST") {
+		t.Fatal("request should show identity header")
 	}
 	if !contains(t, out, "HEADERS") {
-		t.Fatal("payload should contain 'HEADERS'")
+		t.Fatal("request should contain 'HEADERS'")
 	}
 	if !contains(t, out, "BODY") {
-		t.Fatal("payload should contain 'BODY'")
+		t.Fatal("request should contain 'BODY'")
 	}
 	if !contains(t, out, "Content-Type") {
-		t.Fatal("payload should contain header key")
+		t.Fatal("request should contain header key")
 	}
 	if !contains(t, out, "application/json") {
-		t.Fatal("payload should contain header value")
+		t.Fatal("request should contain header value")
 	}
 }
 
 func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
-	if !contains(t, out, "Payload") {
-		t.Fatal("payload should show identity header")
+	out := m.renderRequest(Region{Width: 96, Height: 20})
+	if !contains(t, out, "REQUEST") {
+		t.Fatal("request should show identity header")
 	}
 	if !contains(t, out, "No headers configured.") {
-		t.Fatal("payload should show 'No headers configured.' when no headers")
+		t.Fatal("request should show 'No headers configured.' when no headers")
 	}
 }
 
 func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
-	if !contains(t, out, "Payload") {
+	out := m.renderRequest(Region{Width: 96, Height: 20})
+	if !contains(t, out, "REQUEST") {
 		t.Fatal("payload should show identity header")
 	}
 	if !contains(t, out, `{"name":"pulse"}`) {
@@ -880,49 +879,57 @@ func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	}
 }
 
-func TestRenderEndpoint_Identity(t *testing.T) {
+func TestRenderRequest_Identity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	out := m.renderEndpoint(Region{Width: 100, Height: 20})
-	if !contains(t, out, "Endpoint") {
-		t.Fatal("endpoint should show identity header")
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
+	m.urlInput.Focus()
+	out := m.renderRequest(Region{Width: 100, Height: 20})
+	if !contains(t, out, "REQUEST") {
+		t.Fatal("request should show identity header")
 	}
 	if !contains(t, out, "URL") {
-		t.Fatal("endpoint editor should show URL label")
+		t.Fatal("request should show URL label")
 	}
 	if !contains(t, out, "Method") {
-		t.Fatal("endpoint editor should show Method label")
+		t.Fatal("request should show Method label")
 	}
 	if !contains(t, out, "GET") {
-		t.Fatal("endpoint editor should show method options")
+		t.Fatal("request should show method options")
 	}
 }
 
-func TestRenderConcurrency_Identity(t *testing.T) {
+func TestRenderRequest_ExecutionIdentity(t *testing.T) {
 	m := NewModel()
 	m.width = 100
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.setConcurrency(7)
-	out := m.renderConcurrency(Region{Width: 100, Height: 20})
-	if !contains(t, out, "Concurrency") {
-		t.Fatal("concurrency should show identity header")
+	out := m.renderRequest(Region{Width: 100, Height: 20})
+	if !contains(t, out, "REQUEST") {
+		t.Fatal("request should show identity header")
 	}
 	if !contains(t, out, "7") {
-		t.Fatal("concurrency editor should show current value")
+		t.Fatal("execution should show current concurrency value")
 	}
 	if !contains(t, out, "1–100") {
-		t.Fatal("concurrency should show range affordance")
+		t.Fatal("execution should show range affordance")
 	}
 }
 
 func TestRenderEndpoint_Focused(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogEndpoint
+	m.dialog = dialogRequest
+	m.activeDomain = domainRequest
+	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 	m.urlInput.SetValue("https://example.com/api")
 
-	out := m.renderEndpoint(Region{Width: 100, Height: 20})
-	if !contains(t, out, "Endpoint") {
+	out := m.renderRequest(Region{Width: 100, Height: 20})
+	if !contains(t, out, "REQUEST") {
 		t.Fatal("should show identity")
 	}
 	if !contains(t, out, "api") {
@@ -936,12 +943,13 @@ func TestRenderEndpoint_Focused(t *testing.T) {
 func TestRenderConcurrency_Focused(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogConcurrency
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
 	m.ccInput.Focus()
 	m.setConcurrency(7)
 
-	out := m.renderConcurrency(Region{Width: 100, Height: 20})
-	if !contains(t, out, "Concurrency") {
+	out := m.renderRequest(Region{Width: 100, Height: 20})
+	if !contains(t, out, "REQUEST") {
 		t.Fatal("should show identity")
 	}
 	if !contains(t, out, "1–100") {
@@ -955,7 +963,8 @@ func TestRenderConcurrency_Focused(t *testing.T) {
 func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
@@ -963,7 +972,7 @@ func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 	m.headers[0].Key.Focus()
 	m.headers[0].Value.SetValue("application/json")
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
+	out := m.renderRequest(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Content-Type") {
 		t.Fatal("should show header key")
 	}
@@ -981,7 +990,8 @@ func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusValue
 	m.headers = append(m.headers, newHeaderRow())
@@ -989,7 +999,7 @@ func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 	m.headers[0].Value.SetValue("application/json")
 	m.headers[0].Value.Focus()
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
+	out := m.renderRequest(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Content-Type") {
 		t.Fatal("should show header key")
 	}
@@ -1007,13 +1017,14 @@ func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 func TestRenderPayload_BodyFocus(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = bodyFocus
 	m.bodyInput.Focus()
 	m.bodyInput.SetValue(`{"key": "value"}`)
 	m.headers = append(m.headers, newHeaderRow())
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
+	out := m.renderRequest(Region{Width: 96, Height: 20})
 	if !contains(t, out, `{"key": "value"}`) {
 		t.Fatal("should show body content")
 	}
@@ -1081,7 +1092,8 @@ func TestRenderTimeline_Rows_Selected(t *testing.T) {
 func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.headers = append(m.headers, newHeaderRow(), newHeaderRow(), newHeaderRow())
 	m.headers[0].Key.SetValue("Authorization")
 	m.headers[0].Value.SetValue("Bearer token")
@@ -1089,12 +1101,12 @@ func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 	m.headers[1].Value.SetValue("application/json")
 	m.selectedHead = 1
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
+	out := m.renderRequest(Region{Width: 96, Height: 20})
 	if !contains(t, out, "Authorization") {
-		t.Fatal("payload should show first header key")
+		t.Fatal("request should show first header key")
 	}
 	if !contains(t, out, "Content-Type") {
-		t.Fatal("payload should show second header key")
+		t.Fatal("request should show second header key")
 	}
 	// selected row should have cursor
 	if !contains(t, out, "▶ Content-Type") {
@@ -1105,32 +1117,34 @@ func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 func TestRenderPayload_BodyFocusColor(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	m.selectedHead = bodyFocus
 	m.headers = append(m.headers, newHeaderRow())
 
-	out := m.renderPayload(Region{Width: 96, Height: 20})
+	out := m.renderRequest(Region{Width: 96, Height: 20})
 	if !contains(t, out, "BODY") {
-		t.Fatal("payload should show BODY label")
+		t.Fatal("request should show BODY label")
 	}
 }
 
-func TestRenderRibbon_PayloadDialog(t *testing.T) {
+func TestRenderRibbon_RequestPayloadDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Tab] Next") {
-		t.Fatal("payload ribbon should show [Tab] Next")
+		t.Fatal("request payload ribbon should show [Tab] Next")
 	}
 	if !contains(t, out, "[Ctrl+N] Header") {
-		t.Fatal("payload ribbon should show [Ctrl+N] Header")
+		t.Fatal("request payload ribbon should show [Ctrl+N] Header")
 	}
 	if !contains(t, out, "[Ctrl+D] Delete") {
-		t.Fatal("payload ribbon should show [Ctrl+D] Delete")
+		t.Fatal("request payload ribbon should show [Ctrl+D] Delete")
 	}
 	if !contains(t, out, "[Esc] Back") {
-		t.Fatal("payload ribbon should show [Esc] Back")
+		t.Fatal("request payload ribbon should show [Esc] Back")
 	}
 }
 
@@ -1188,8 +1202,8 @@ func TestOrientationLabel_WithResults(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "TIMELINE" {
-		t.Fatalf("results orientationLabel = %q, want TIMELINE", got)
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("results orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
@@ -1197,8 +1211,8 @@ func TestOrientationLabel_RunningEmpty(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	m.running = true
-	if got := m.orientationLabel(); got != "TIMELINE" {
-		t.Fatalf("running empty orientationLabel = %q, want TIMELINE", got)
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("running empty orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
@@ -1207,8 +1221,8 @@ func TestOrientationLabel_RunningWithResults(t *testing.T) {
 	m.width = 100
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "TIMELINE" {
-		t.Fatalf("running+results orientationLabel = %q, want TIMELINE", got)
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("running+results orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
@@ -1217,8 +1231,8 @@ func TestOrientationLabel_LogsView(t *testing.T) {
 	m.width = 100
 	m.view = viewLogs
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "LOGS" {
-		t.Fatalf("logs view orientationLabel = %q, want LOGS", got)
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("logs view orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
@@ -1228,35 +1242,37 @@ func TestOrientationLabel_RunningLogsView(t *testing.T) {
 	m.running = true
 	m.view = viewLogs
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "LOGS" {
-		t.Fatalf("running+logs orientationLabel = %q, want LOGS", got)
+	if got := m.orientationLabel(); got != "OBSERVE" {
+		t.Fatalf("running+logs orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
-func TestOrientationLabel_EndpointDialog(t *testing.T) {
+func TestOrientationLabel_RequestDialog(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogEndpoint
-	if got := m.orientationLabel(); got != "ENDPOINT" {
-		t.Fatalf("endpoint dialog orientationLabel = %q, want ENDPOINT", got)
+	m.dialog = dialogRequest
+	if got := m.orientationLabel(); got != "REQUEST" {
+		t.Fatalf("request dialog orientationLabel = %q, want REQUEST", got)
 	}
 }
 
-func TestOrientationLabel_ConcurrencyDialog(t *testing.T) {
+func TestOrientationLabel_ExecDomain(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogConcurrency
-	if got := m.orientationLabel(); got != "CONCURRENCY" {
-		t.Fatalf("concurrency dialog orientationLabel = %q, want CONCURRENCY", got)
+	m.dialog = dialogRequest
+	m.activeDomain = domainExec
+	if got := m.orientationLabel(); got != "REQUEST" {
+		t.Fatalf("request dialog (exec) orientationLabel = %q, want REQUEST", got)
 	}
 }
 
-func TestOrientationLabel_PayloadDialog(t *testing.T) {
+func TestOrientationLabel_PayloadDomain(t *testing.T) {
 	m := NewModel()
 	m.width = 100
-	m.dialog = dialogPayload
-	if got := m.orientationLabel(); got != "PAYLOAD" {
-		t.Fatalf("payload dialog orientationLabel = %q, want PAYLOAD", got)
+	m.dialog = dialogRequest
+	m.activeDomain = domainPayload
+	if got := m.orientationLabel(); got != "REQUEST" {
+		t.Fatalf("request dialog (payload) orientationLabel = %q, want REQUEST", got)
 	}
 }
 
@@ -1282,10 +1298,14 @@ func TestRenderRibbon_ShellColumnWidth(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderRibbon(m.ShellState(), 100)
-	// Shell column must contain orientation label right-padded to ShellColumnWidth.
-	// "OBSERVE        " (7 + 9 padding = 16) followed by gutter "  ".
-	if !contains(t, out, "OBSERVE        ") {
-		t.Fatal("ribbon should right-pad OBSERVE to ShellColumnWidth (16)")
+	// Shell column must contain orientation label with accent anchor prefix.
+	// Format: "│ OBSERVE      " (anchor + space + 7-char label padded to 14 = 16).
+	if !contains(t, out, "OBSERVE") {
+		t.Fatal("ribbon should show orientation label")
+	}
+	// Ribbon should have the shell anchor character
+	if !contains(t, out, "│") {
+		t.Fatal("ribbon should show shell anchor (│)")
 	}
 }
 
@@ -1307,12 +1327,12 @@ func TestRenderRibbon_CategoryOrder(t *testing.T) {
 	// With results: Navigation → Configuration → Operation → Application.
 	// Navigation must appear before Configuration.
 	navIdx := strings.Index(out, "[↑↓] Select")
-	cfgIdx := strings.Index(out, "[e] Endpoint")
+	cfgIdx := strings.Index(out, "[e] Request")
 	if navIdx < 0 {
 		t.Fatal("ribbon should include [↑↓] Select when results exist")
 	}
 	if cfgIdx < 0 {
-		t.Fatal("ribbon should include [e] Endpoint when results exist")
+		t.Fatal("ribbon should include [e] Request when results exist")
 	}
 	if navIdx > cfgIdx {
 		t.Fatal("Navigation group must render before Configuration group")
@@ -1323,10 +1343,9 @@ func TestRenderRibbon_WithinGroupSeparator(t *testing.T) {
 	m := NewModel()
 	m.width = 100
 	out := m.renderRibbon(m.ShellState(), 100)
-	// Ready state: [e] Endpoint, [c] Concurrency, [p] Payload — all in Configuration group.
-	// They must be separated by " · " (space-bullet-space).
-	if !contains(t, out, "[e] Endpoint · [c] Concurrency · [p] Payload") {
-		t.Fatal("commands within same category should be separated by ' · '")
+	// Ready state: [e] Request in Configuration group.
+	if !contains(t, out, "[e] Request") {
+		t.Fatal("ready state should show [e] Request")
 	}
 }
 
@@ -1336,7 +1355,7 @@ func TestRenderRibbon_BetweenGroupSeparator(t *testing.T) {
 	out := m.renderRibbon(m.ShellState(), 100)
 	// Ready state: Configuration group followed by Operation group.
 	// Must have 4-space gap between groups.
-	if !contains(t, out, "Payload    [Ctrl+R]") {
+	if !contains(t, out, "Request    [Ctrl+R]") {
 		t.Fatal("different category groups must be separated by wider gap (4 spaces)")
 	}
 }
@@ -1357,52 +1376,37 @@ func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
 		t.Fatal("renderReady must not render shell separators")
 	}
 
-	// renderEndpoint
+	// renderRequest
 	m2 := NewModel()
 	m2.width = 100
-	m2.dialog = dialogEndpoint
-	if contains(t, m2.renderEndpoint(region), "─") {
-		t.Fatal("renderEndpoint must not render shell separators")
-	}
-
-	// renderConcurrency
-	m3 := NewModel()
-	m3.width = 100
-	m3.dialog = dialogConcurrency
-	if contains(t, m3.renderConcurrency(region), "─") {
-		t.Fatal("renderConcurrency must not render shell separators")
-	}
-
-	// renderPayload
-	m4 := NewModel()
-	m4.width = 100
-	m4.dialog = dialogPayload
-	if contains(t, m4.renderPayload(region), "─") {
-		t.Fatal("renderPayload must not render shell separators")
+	m2.dialog = dialogRequest
+	m2.activeDomain = domainRequest
+	if contains(t, m2.renderRequest(region), "─") {
+		t.Fatal("renderRequest must not render shell separators")
 	}
 
 	// renderTimeline
-	m5 := NewModel()
-	m5.width = 100
-	m5.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if contains(t, m5.renderTimeline(region), "─") {
+	m3 := NewModel()
+	m3.width = 100
+	m3.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m3.renderTimeline(region), "─") {
 		t.Fatal("renderTimeline must not render shell separators")
 	}
 
 	// renderLogs
-	m6 := NewModel()
-	m6.width = 100
-	m6.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if contains(t, m6.renderLogs(region), "─") {
+	m4 := NewModel()
+	m4.width = 100
+	m4.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m4.renderLogs(region), "─") {
 		t.Fatal("renderLogs must not render shell separators")
 	}
 
 	// renderInspect
-	m7 := NewModel()
-	m7.width = 100
-	m7.selected = 0
-	m7.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if contains(t, m7.renderInspect(Region{Width: 40, Height: 20}), "─") {
+	m5 := NewModel()
+	m5.width = 100
+	m5.selected = 0
+	m5.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
+	if contains(t, m5.renderInspect(Region{Width: 40, Height: 20}), "─") {
 		t.Fatal("renderInspect must not render shell separators")
 	}
 }
@@ -1413,7 +1417,7 @@ func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
 func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
 	region := Region{Width: 100, Height: 26}
 
-	shortcutPatterns := []string{"Ctrl+", "[Esc]", "[Tab]", "[Enter]", "[↑↓]", "[←→]", "[q]", "[e]", "[c]", "[p]"}
+	shortcutPatterns := []string{"Ctrl+", "[Esc]", "[Tab]", "[Enter]", "[↑↓]", "[←→]", "[q]", "[e]"}
 
 	m := NewModel()
 	m.width = 100
@@ -1424,22 +1428,14 @@ func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
 		}
 	}
 
-	// Verify all dialog surfaces also follow this rule.
+	// Verify the REQUEST surface also follows this rule.
 	m2 := NewModel()
 	m2.width = 100
-	m2.dialog = dialogEndpoint
+	m2.dialog = dialogRequest
+	m2.activeDomain = domainRequest
 	for _, pat := range shortcutPatterns {
-		if contains(t, m2.renderEndpoint(region), pat) {
-			t.Fatalf("Endpoint surface must not contain %q", pat)
-		}
-	}
-
-	m3 := NewModel()
-	m3.width = 100
-	m3.dialog = dialogConcurrency
-	for _, pat := range shortcutPatterns {
-		if contains(t, m3.renderConcurrency(region), pat) {
-			t.Fatalf("Concurrency surface must not contain %q", pat)
+		if contains(t, m2.renderRequest(region), pat) {
+			t.Fatalf("Request surface must not contain %q", pat)
 		}
 	}
 }
@@ -1447,7 +1443,7 @@ func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
 // TestShellInvariant_RibbonHasOrientation verifies every ribbon output starts
 // with a known orientation label (the Shell Column).
 func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
-	labels := []string{"OBSERVE", "TIMELINE", "LOGS", "INSPECT", "ENDPOINT", "CONCURRENCY", "PAYLOAD", "QUIT"}
+	labels := []string{"OBSERVE", "REQUEST", "INSPECT", "QUIT"}
 	hasLabel := func(out string) bool {
 		for _, l := range labels {
 			if contains(t, out, l) {
@@ -1489,12 +1485,12 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 		t.Fatal("ribbon must show orientation label in inspect mode")
 	}
 
-	// Endpoint dialog
+	// Request dialog
 	m5 := NewModel()
 	m5.width = 100
-	m5.dialog = dialogEndpoint
+	m5.dialog = dialogRequest
 	if !hasLabel(m5.renderRibbon(m5.ShellState(), 100)) {
-		t.Fatal("ribbon must show orientation label in endpoint dialog")
+		t.Fatal("ribbon must show orientation label in request dialog")
 	}
 
 	// ConfirmQuit dialog
@@ -1515,9 +1511,24 @@ func TestShellInvariant_ActionsAreIntents(t *testing.T) {
 		func() []Action { m := NewModel(); m.running = true; return m.Actions() },
 		func() []Action { m := NewModel(); m.running = true; m.results = []model.Result{{}}; return m.Actions() },
 		func() []Action { m := NewModel(); m.results = []model.Result{{}}; return m.Actions() },
-		func() []Action { m := NewModel(); m.dialog = dialogEndpoint; return m.Actions() },
-		func() []Action { m := NewModel(); m.dialog = dialogConcurrency; return m.Actions() },
-		func() []Action { m := NewModel(); m.dialog = dialogPayload; return m.Actions() },
+		func() []Action {
+			m := NewModel()
+			m.dialog = dialogRequest
+			m.activeDomain = domainRequest
+			return m.Actions()
+		},
+		func() []Action {
+			m := NewModel()
+			m.dialog = dialogRequest
+			m.activeDomain = domainExec
+			return m.Actions()
+		},
+		func() []Action {
+			m := NewModel()
+			m.dialog = dialogRequest
+			m.activeDomain = domainPayload
+			return m.Actions()
+		},
 		func() []Action { m := NewModel(); m.mode = modeInspect; return m.Actions() },
 		func() []Action { m := NewModel(); m.dialog = dialogConfirmQuit; return m.Actions() },
 	}
@@ -1613,8 +1624,8 @@ func TestShellState_UpdatesWithState(t *testing.T) {
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 
 	s := m.ShellState()
-	if s.Orientation != "TIMELINE" {
-		t.Fatalf("running state ShellState.Orientation = %q, want TIMELINE", s.Orientation)
+	if s.Orientation != "OBSERVE" {
+		t.Fatalf("running state ShellState.Orientation = %q, want OBSERVE", s.Orientation)
 	}
 }
 


### PR DESCRIPTION
Consolidate three separate dialogs (Endpoint, Concurrency, Payload) into one unified REQUEST workspace with three domains (Request, Payload, Execution), establishing the permanent six-contract operator model.

Contracts frozen:
  - Workspace: 4 permanent (OBSERVE, REQUEST, INSPECT, QUIT)
  - Domain:    REQUEST → Request / Payload / Execution
  - Action:    presentation-independent, grouped by operator intention
  - Interaction: Tab traverses operator workflow, Shift+Tab exact reverse
  - Focus:     Idle → Focused → Editing state machine
  - Recovery:  Esc recovers one level, no destructive action one key away

Implementation:
  model.go:  Added requestDomain, dialogRequest, activeDomain,
             handleRequestKey, advanceDomain (Tab traversal),
             three domain key handlers, setBodyWidths helper
  view.go:   Added renderRequest (all three domains), orientationLabel
             (4 workspaces), Actions() from workspace+domain,
             accentOrMuted, isErrorResult helpers, split renderRequest
             into per-domain sub-functions, shell anchor in ribbon
  styles.go: Removed styleStatusMode (dead code)
  audit.go:  Updated AllAuditSurfaces (Request/RequestPayload/RequestExec)

Cleanup:
  - Fix styles_test.go duplicate assertion (GetBackground→GetForeground)
  - Remove testClient duplication in engine_test.go
  - Factor isErrorResult in renderTimelineRow + renderLogs
  - Fix validation_test.go to use t.Errorf in loop

Tests:  All 80+ pass, go vet clean, race detector clean.

Closes #102, #103