### PR TITLE
v0.9.0: Constitutional Architecture, six foundational concepts and finalization

### DIFF
--- a/internal/tui/audit.go
+++ b/internal/tui/audit.go
@@ -38,8 +38,7 @@ func AllAuditSurfaces() []AuditSurface {
 
 func WriteAuditCapture(surface AuditSurface, w, h int, dir string) (string, error) {
 	m := surface.Setup()
-	m.width = w
-	m.height = h
+	m.shell.Resize(w, h)
 	out := m.View()
 	name := fmt.Sprintf("%s_%dx%d.ansi", surface.Name, w, h)
 	path := filepath.Join(dir, name)
@@ -97,7 +96,7 @@ func newInspectModel() Model {
 func newRequestPayloadModel() Model {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = bodyFocus
 	m.headers = []headerRow{newHeaderRow(), newHeaderRow()}
 	m.headers[0].Key.SetValue("Content-Type")
@@ -111,7 +110,7 @@ func newRequestPayloadModel() Model {
 func newRequestModel() Model {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.SetValue("https://httpbin.org/delay/1")
 	m.urlInput.Focus()
@@ -121,7 +120,7 @@ func newRequestModel() Model {
 func newRequestExecModel() Model {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.SetValue("10")
 	m.ccInput.Focus()
 	return m

--- a/internal/tui/domain.go
+++ b/internal/tui/domain.go
@@ -1,0 +1,56 @@
+package tui
+
+// DomainType identifies which domain is active within the Request workspace.
+type DomainType int
+
+const (
+	DomainRequest DomainType = iota
+	DomainPayload
+	DomainExec
+)
+
+// Domain defines the autonomous behavioural unit. Each Domain encapsulates
+// its own behaviour, validation, and action production. A Domain never
+// knows about Shell, other Domains, or the surrounding workspace. A Domain
+// never owns rendering, colours, typography, or layout.
+type Domain interface {
+	Actions(m Model) []Action
+}
+
+// RequestDomain represents the URL/method configuration domain within the
+// Request workspace.
+type RequestDomain struct{}
+
+func (RequestDomain) Actions(m Model) []Action {
+	return []Action{
+		{ActionNextField, ConfigurationCategory, true},
+		{ActionSwitchMethod, ConfigurationCategory, true},
+	}
+}
+
+// PayloadDomain represents the headers/body configuration domain.
+type PayloadDomain struct{}
+
+func (PayloadDomain) Actions(m Model) []Action {
+	return []Action{
+		{ActionNextField, ConfigurationCategory, true},
+		{ActionAddHeader, ConfigurationCategory, true},
+		{ActionDeleteHeader, ConfigurationCategory, true},
+	}
+}
+
+// RunDomain represents the concurrency/execution configuration domain.
+type RunDomain struct{}
+
+func (RunDomain) Actions(m Model) []Action {
+	return []Action{
+		{ActionAdjustConcurrency, ConfigurationCategory, true},
+	}
+}
+
+// domainRegistry maps each DomainType to its Domain instance.
+var domainRegistry = map[DomainType]Domain{
+	DomainRequest: RequestDomain{},
+	DomainPayload: PayloadDomain{},
+	DomainExec:    RunDomain{},
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -17,14 +17,6 @@ import (
 	"github.com/divijg19/Pulse/internal/stream"
 )
 
-type requestDomain int
-
-const (
-	domainRequest requestDomain = iota
-	domainPayload
-	domainExec
-)
-
 const (
 	subfocusKey      = 0
 	subfocusValue    = 1
@@ -64,14 +56,14 @@ type headerRow struct {
 }
 
 type Model struct {
-	width  int
-	height int
+	shell     Shell
+	workspace Workspace
 
 	mode   mode
 	dialog dialog
 	view   view
 
-	activeDomain requestDomain
+	activeDomain DomainType
 	methodIndex  int
 	requestField int
 	urlInput     textinput.Model
@@ -130,10 +122,12 @@ func NewModel() Model {
 	body.SetWidth(defaultBodyWidth)
 
 	return Model{
+		shell:        NewShell(),
+		workspace:    NewWorkspace(),
 		mode:         modeObserve,
 		dialog:       dialogNone,
 		view:         viewTimeline,
-		activeDomain: domainRequest,
+		activeDomain: DomainRequest,
 		methodIndex:  0,
 		requestField: reqFieldURL,
 		urlInput:     url,
@@ -157,14 +151,13 @@ func (m *Model) setBodyWidths(totalWidth int) {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
+		m.shell.Resize(msg.Width, msg.Height)
 		m.setBodyWidths(msg.Width)
 		return m, nil
 	case startupMsg:
-		if m.width == 0 {
-			m.width = 80
-			m.height = 24
+		w, _ := m.shell.Dimensions()
+		if w == 0 {
+			m.shell.Resize(80, 24)
 			m.setBodyWidths(80)
 		}
 		return m, nil
@@ -254,11 +247,11 @@ func (m Model) handleRequestKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	switch m.activeDomain {
-	case domainRequest:
+	case DomainRequest:
 		return m.handleRequestDomainKey(msg)
-	case domainPayload:
+	case DomainPayload:
 		return m.handlePayloadDomainKey(msg)
-	case domainExec:
+	case DomainExec:
 		return m.handleExecDomainKey(msg)
 	}
 	return m, nil
@@ -267,9 +260,9 @@ func (m Model) handleRequestKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) advanceDomain(forward bool) (tea.Model, tea.Cmd) {
 	if forward {
 		switch m.activeDomain {
-		case domainRequest:
+		case DomainRequest:
 			if m.requestField == reqFieldURL {
-				m.activeDomain = domainPayload
+				m.activeDomain = DomainPayload
 				m.selectedHead = 0
 				m.headerSubfocus = subfocusKey
 				if len(m.headers) == 0 {
@@ -280,30 +273,30 @@ func (m Model) advanceDomain(forward bool) (tea.Model, tea.Cmd) {
 				m.requestField = reqFieldURL
 				m.urlInput.Focus()
 			}
-		case domainPayload:
+		case DomainPayload:
 			if m.selectedHead == bodyFocus {
-				m.activeDomain = domainExec
+				m.activeDomain = DomainExec
 				m.ccInput.Focus()
 			} else {
 				m.selectedHead = bodyFocus
 				m.focusPayloadBody()
 			}
-		case domainExec:
-			m.activeDomain = domainRequest
+		case DomainExec:
+			m.activeDomain = DomainRequest
 			m.requestField = reqFieldMethod
 			m.blurAll()
 		}
 	} else {
 		switch m.activeDomain {
-		case domainRequest:
+		case DomainRequest:
 			if m.requestField == reqFieldMethod {
-				m.activeDomain = domainExec
+				m.activeDomain = DomainExec
 				m.ccInput.Focus()
 			} else {
 				m.requestField = reqFieldMethod
 				m.blurAll()
 			}
-		case domainPayload:
+		case DomainPayload:
 			if m.selectedHead == bodyFocus {
 				if len(m.headers) == 0 {
 					m.headers = append(m.headers, newHeaderRow())
@@ -312,12 +305,12 @@ func (m Model) advanceDomain(forward bool) (tea.Model, tea.Cmd) {
 				m.headerSubfocus = subfocusKey
 				m.focusPayloadKey()
 			} else {
-				m.activeDomain = domainRequest
+				m.activeDomain = DomainRequest
 				m.requestField = reqFieldURL
 				m.urlInput.Focus()
 			}
-		case domainExec:
-			m.activeDomain = domainPayload
+		case DomainExec:
+			m.activeDomain = DomainPayload
 			m.selectedHead = bodyFocus
 			m.focusPayloadBody()
 		}
@@ -479,13 +472,15 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "pgup":
 		if len(m.results) > 0 {
-			pageSize := max(5, m.height/2)
+			_, h := m.shell.Dimensions()
+			pageSize := max(5, h/2)
 			m.selected = max(0, m.selected-pageSize)
 		}
 		return m, nil
 	case "pgdown":
 		if len(m.results) > 0 {
-			pageSize := max(5, m.height/2)
+			_, h := m.shell.Dimensions()
+			pageSize := max(5, h/2)
 			m.selected = min(len(m.results)-1, m.selected+pageSize)
 		}
 		return m, nil
@@ -503,7 +498,7 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "e":
 		m.dialog = dialogRequest
 		m.blurAll()
-		m.activeDomain = domainRequest
+		m.activeDomain = DomainRequest
 		m.requestField = reqFieldURL
 		m.urlInput.Focus()
 		return m, nil
@@ -512,11 +507,8 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+x":
 		return m.cancelRun(), nil
 	case "q", "ctrl+c":
-		if m.running {
-			m.dialog = dialogConfirmQuit
-			return m, nil
-		}
-		return m, tea.Quit
+		m.dialog = dialogConfirmQuit
+		return m, nil
 	}
 	return m, nil
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -15,7 +15,7 @@ import (
 func TestMethodSelection(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
@@ -25,7 +25,7 @@ func TestMethodSelection(t *testing.T) {
 	if m.dialog != dialogRequest {
 		t.Fatal("tab should not close request dialog")
 	}
-	if m.activeDomain != domainPayload {
+	if m.activeDomain != DomainPayload {
 		t.Fatal("tab from URL field should advance to payload domain")
 	}
 }
@@ -45,14 +45,14 @@ func TestConcurrencyClamping(t *testing.T) {
 func TestPayloadEditorState(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 
 	if m.dialog != dialogRequest {
 		t.Fatal("request dialog should be active")
 	}
-	if m.activeDomain != domainPayload {
+	if m.activeDomain != DomainPayload {
 		t.Fatal("payload domain should be active")
 	}
 	if len(m.headers) != 0 {
@@ -103,7 +103,7 @@ func TestViewSwitching(t *testing.T) {
 
 func TestResultSelection_PageUpDown(t *testing.T) {
 	m := NewModel()
-	m.height = 30
+	m.shell.Resize(80, 30)
 	for i := 0; i < 50; i++ {
 		m.results = append(m.results, model.Result{Status: 200})
 	}
@@ -156,7 +156,7 @@ func TestResultSelectionAndInspect(t *testing.T) {
 func TestHeaderAddRemove(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
@@ -267,8 +267,9 @@ func TestWindowSizeMsg(t *testing.T) {
 	initialWidth := m.bodyInput.Width()
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 	m = updated.(Model)
-	if m.width != 120 || m.height != 40 {
-		t.Fatalf("width/height = %d/%d", m.width, m.height)
+	w, h := m.shell.Dimensions()
+	if w != 120 || h != 40 {
+		t.Fatalf("width/height = %d/%d", w, h)
 	}
 	if got := m.bodyInput.Width(); got <= initialWidth {
 		t.Fatalf("bodyInput.Width() = %d after resize to 120, expected > initial %d", got, initialWidth)
@@ -321,10 +322,13 @@ func TestCtrlC_QuitIdle(t *testing.T) {
 	m.running = false
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
-	_ = updated.(Model)
+	m = updated.(Model)
 
-	if cmd == nil {
-		t.Fatal("ctrl+c while idle should return a quit command")
+	if cmd != nil {
+		t.Fatal("ctrl+c while idle should return nil cmd (opens confirmation)")
+	}
+	if m.dialog != dialogConfirmQuit {
+		t.Fatal("ctrl+c while idle should open confirmation dialog")
 	}
 }
 
@@ -333,10 +337,13 @@ func TestQ_QuitIdle(t *testing.T) {
 	m.running = false
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
-	_ = updated.(Model)
+	m = updated.(Model)
 
-	if cmd == nil {
-		t.Fatal("q while idle should return a quit command")
+	if cmd != nil {
+		t.Fatal("q while idle should return nil cmd (opens confirmation)")
+	}
+	if m.dialog != dialogConfirmQuit {
+		t.Fatal("q while idle should open confirmation dialog")
 	}
 }
 
@@ -424,11 +431,12 @@ func TestStartupMsg_SetsDefaults(t *testing.T) {
 	m := NewModel()
 	updated, _ := m.Update(startupMsg{})
 	m = updated.(Model)
-	if m.width != 80 {
-		t.Fatalf("width = %d, want 80", m.width)
+	w, h := m.shell.Dimensions()
+	if w != 80 {
+		t.Fatalf("width = %d, want 80", w)
 	}
-	if m.height != 24 {
-		t.Fatalf("height = %d, want 24", m.height)
+	if h != 24 {
+		t.Fatalf("height = %d, want 24", h)
 	}
 }
 
@@ -438,7 +446,8 @@ func TestStartupMsg_AfterWindowSize(t *testing.T) {
 	m = updated.(Model)
 	updated, _ = m.Update(startupMsg{})
 	m = updated.(Model)
-	if m.width != 120 {
+	w, _ := m.shell.Dimensions()
+	if w != 120 {
 		t.Fatal("startupMsg should not override existing width")
 	}
 }
@@ -606,7 +615,7 @@ func TestObserve_EndpointDialogOpenClose(t *testing.T) {
 	if m.dialog != dialogRequest {
 		t.Fatal("pressing e should open request dialog")
 	}
-	if m.activeDomain != domainRequest {
+	if m.activeDomain != DomainRequest {
 		t.Fatal("pressing e should set active domain to request")
 	}
 
@@ -620,13 +629,13 @@ func TestObserve_EndpointDialogOpenClose(t *testing.T) {
 func TestObserve_CCDialogOpenClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.Focus()
 
 	if m.dialog != dialogRequest {
 		t.Fatal("request dialog should be active")
 	}
-	if m.activeDomain != domainExec {
+	if m.activeDomain != DomainExec {
 		t.Fatal("execution domain should be active")
 	}
 
@@ -641,14 +650,14 @@ func TestObserve_CCDialogOpenClose(t *testing.T) {
 func TestObserve_PayloadDialogOpenClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 
 	if m.dialog != dialogRequest {
 		t.Fatal("request dialog should be active")
 	}
-	if m.activeDomain != domainPayload {
+	if m.activeDomain != DomainPayload {
 		t.Fatal("payload domain should be active")
 	}
 	if len(m.headers) != 0 {
@@ -666,7 +675,7 @@ func TestObserve_PayloadDialogOpenClose(t *testing.T) {
 func TestCCDialog_ArrowAdjustUp(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 
 	initial := m.concurrency()
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -680,7 +689,7 @@ func TestCCDialog_ArrowAdjustUp(t *testing.T) {
 func TestCCDialog_ArrowAdjustDown(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.setConcurrency(50)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
@@ -694,7 +703,7 @@ func TestCCDialog_ArrowAdjustDown(t *testing.T) {
 func TestEndpointDialog_EscCloses(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
@@ -708,7 +717,7 @@ func TestEndpointDialog_EscCloses(t *testing.T) {
 func TestEndpointDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
@@ -722,7 +731,7 @@ func TestEndpointDialog_EnterDoesNotClose(t *testing.T) {
 func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldMethod
 
 	methods := runconfig.AllowedMethods()
@@ -765,14 +774,14 @@ func TestEndpointDialog_MethodSwitchingLeftRight(t *testing.T) {
 func TestEndpointDialog_TabSwitchesField(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
 	// Tab should advance to payload domain (URL → Payload)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.activeDomain != domainPayload {
+	if m.activeDomain != DomainPayload {
 		t.Fatal("tab from URL field should advance to payload domain")
 	}
 }
@@ -780,7 +789,7 @@ func TestEndpointDialog_TabSwitchesField(t *testing.T) {
 func TestEndpointDialog_LeftRightOnUrlDoesNotChangeMethod(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
@@ -803,7 +812,7 @@ func TestEndpointDialog_LeftRightOnUrlDoesNotChangeMethod(t *testing.T) {
 func TestCCDialog_EscCloses(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -816,7 +825,7 @@ func TestCCDialog_EscCloses(t *testing.T) {
 func TestCCDialog_EnterDoesNotClose(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -878,7 +887,7 @@ func TestViewSwitch_PreservesSelection(t *testing.T) {
 func TestEndpointDialog_NotClosableByWrongKey(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 
@@ -896,7 +905,7 @@ func TestEndpointDialog_NotClosableByWrongKey(t *testing.T) {
 func TestCCDialog_TypesDigits(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.Focus()
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -910,7 +919,7 @@ func TestCCDialog_TypesDigits(t *testing.T) {
 func TestPayloadDialog_HeaderNavigationUpDown(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow(), newHeaderRow())
@@ -945,7 +954,7 @@ func TestPayloadDialog_HeaderNavigationUpDown(t *testing.T) {
 func TestPayloadDialog_TabToBody(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
@@ -960,7 +969,7 @@ func TestPayloadDialog_TabToBody(t *testing.T) {
 	// Tab from body → next domain (execution)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.activeDomain != domainExec {
+	if m.activeDomain != DomainExec {
 		t.Fatalf("tab from body should advance to execution domain, got domain=%d", m.activeDomain)
 	}
 }
@@ -1023,7 +1032,7 @@ func TestConfirmQuit_FromInspectMode(t *testing.T) {
 func TestCCDialog_ClampAtMax(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.setConcurrency(100)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -1036,7 +1045,7 @@ func TestCCDialog_ClampAtMax(t *testing.T) {
 func TestCCDialog_ClampAtMin(t *testing.T) {
 	m := NewModel()
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.setConcurrency(1)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})

--- a/internal/tui/region.go
+++ b/internal/tui/region.go
@@ -1,0 +1,10 @@
+package tui
+
+// RegionType distinguishes the two kinds of region in the Shell layout.
+type RegionType int
+
+const (
+	ContextRegion RegionType = iota
+	WorkspaceRegion
+	CommandRegion
+)

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -1,0 +1,150 @@
+package tui
+
+// Region is a rectangular area within a layout.
+type Region struct {
+	Width  int
+	Height int
+}
+
+// ShellLayout divides the terminal into the three permanent Shell regions.
+type ShellLayout struct {
+	Context   Region
+	Workspace Region
+	Command   Region
+}
+
+// ShellColumnWidth is the fixed width reserved for the orientation label
+// in the operator ribbon.
+const ShellColumnWidth = 16
+
+// ActionCategory defines the four semantic groups an action can belong to.
+type ActionCategory int
+
+const (
+	NavigationCategory ActionCategory = iota
+	ConfigurationCategory
+	OperationCategory
+	ApplicationCategory
+)
+
+// ActionID identifies an operator intent.
+type ActionID int
+
+const (
+	ActionSelect ActionID = iota
+	ActionInspect
+	ActionSwitchView
+	ActionConfigureRequest
+	ActionRun
+	ActionCancel
+	ActionNextField
+	ActionSwitchMethod
+	ActionAdjustConcurrency
+	ActionNextHeader
+	ActionAddHeader
+	ActionDeleteHeader
+	ActionBack
+	ActionQuit
+	ActionConfirmQuit
+	ActionCtrlCQuit
+	ActionQQuit
+	ActionDismissCancel
+)
+
+// Action is a behavioral intent — not a presentation object.
+type Action struct {
+	ID       ActionID
+	Category ActionCategory
+	Enabled  bool
+}
+
+// configItem represents a single configuration value in the Context region.
+type configItem struct {
+	Identity string
+	Value    string
+	Valid    bool
+}
+
+// ShellState is an immutable snapshot of the shell-level state produced once
+// per frame.
+type ShellState struct {
+	Orientation   string
+	Configuration []configItem
+	Actions       []Action
+}
+
+// actionBinding maps an operator intent (ActionID) to its presentation in the
+// operator ribbon.
+type actionBinding struct {
+	Key      string
+	Label    string
+	Category ActionCategory
+}
+
+var actionBindings = map[ActionID]actionBinding{
+	ActionSelect:            {"↑↓", "Select", NavigationCategory},
+	ActionInspect:           {"Enter", "Inspect", NavigationCategory},
+	ActionSwitchView:        {"Tab", "Views", NavigationCategory},
+	ActionConfigureRequest:  {"e", "Request", ConfigurationCategory},
+	ActionRun:               {"Ctrl+R", "Run", OperationCategory},
+	ActionCancel:            {"Ctrl+X", "Cancel", OperationCategory},
+	ActionNextField:         {"Tab", "Next Field", ConfigurationCategory},
+	ActionSwitchMethod:      {"←→", "Method", ConfigurationCategory},
+	ActionAdjustConcurrency: {"↑↓", "Adjust", ConfigurationCategory},
+	ActionNextHeader:        {"Tab", "Next", ConfigurationCategory},
+	ActionAddHeader:         {"Ctrl+N", "Header", ConfigurationCategory},
+	ActionDeleteHeader:      {"Ctrl+D", "Delete", ConfigurationCategory},
+	ActionBack:              {"Esc", "Back", ApplicationCategory},
+	ActionQuit:              {"q", "Quit", ApplicationCategory},
+	ActionConfirmQuit:       {"Enter", "Quit", ApplicationCategory},
+	ActionCtrlCQuit:         {"Ctrl+C", "Quit", ApplicationCategory},
+	ActionQQuit:             {"q", "Quit", ApplicationCategory},
+	ActionDismissCancel:     {"Any", "Cancel", ApplicationCategory},
+}
+
+// Shell is the permanent outer boundary of Pulse. It owns orientation,
+// the context bar, the ribbon, and terminal geometry.
+type Shell struct {
+	width  int
+	height int
+}
+
+func NewShell() Shell {
+	return Shell{width: 80, height: 24}
+}
+
+func (s *Shell) Resize(w, h int) {
+	s.width = w
+	s.height = h
+}
+
+func (s Shell) Dimensions() (int, int) {
+	return s.width, s.height
+}
+
+func (s Shell) Layout() ShellLayout {
+	return computeShellLayout(s.width, s.height)
+}
+
+func computeShellLayout(totalWidth, totalHeight int) ShellLayout {
+	width := max(72, totalWidth)
+	bodyHeight := max(1, totalHeight-5)
+	return ShellLayout{
+		Context:   Region{Width: width, Height: 1},
+		Workspace: Region{Width: width, Height: bodyHeight},
+		Command:   Region{Width: width, Height: 1},
+	}
+}
+
+func orientationLabel(m Model) string {
+	switch {
+	case m.dialog == dialogConfirmQuit:
+		return "QUIT"
+	case m.mode == modeInspect:
+		return "INSPECT"
+	case m.dialog == dialogRequest:
+		return "REQUEST"
+	default:
+		return "OBSERVE"
+	}
+}

--- a/internal/tui/surface.go
+++ b/internal/tui/surface.go
@@ -1,0 +1,32 @@
+package tui
+
+// Surface presents a Domain within a Region. Each Surface knows how to
+// render a specific Domain's state into a bounded rectangular area.
+// Substitutability Law: any Surface may be replaced without changing the
+// Domain it presents.
+type Surface interface {
+	Render(region Region) string
+}
+
+// surfaceFunc adapts a function to the Surface interface.
+type surfaceFunc func(Region) string
+
+func (f surfaceFunc) Render(region Region) string {
+	return f(region)
+}
+
+// resolveSurface returns the Surface for the current Model state.
+func (m Model) resolveSurface() Surface {
+	switch {
+	case m.dialog == dialogRequest:
+		return surfaceFunc(m.renderRequest)
+	case m.mode == modeInspect:
+		return surfaceFunc(m.renderInspect)
+	case !m.running && len(m.results) == 0:
+		return surfaceFunc(m.renderReady)
+	case m.view == viewTimeline:
+		return surfaceFunc(m.renderTimeline)
+	default:
+		return surfaceFunc(m.renderLogs)
+	}
+}

--- a/internal/tui/v080_audit_test.go
+++ b/internal/tui/v080_audit_test.go
@@ -16,8 +16,7 @@ func TestV080Audit_AllSurfaces(t *testing.T) {
 				s := s
 				t.Run(fmt.Sprintf("%dx%d", s.W, s.H), func(t *testing.T) {
 					m := c.Setup()
-					m.width = s.W
-					m.height = s.H
+					m.shell.Resize(s.W, s.H)
 					out := m.View()
 					t.Logf("=== %s at %dx%d ===\n%s", c.Name, s.W, s.H, out)
 					checkE1(t, out, s.W, s.H, c.Name)
@@ -30,8 +29,7 @@ func TestV080Audit_AllSurfaces(t *testing.T) {
 func TestV080Audit_E1VerticalPadding(t *testing.T) {
 	t.Run("Ready_80x24", func(t *testing.T) {
 		m := newReadyModel()
-		m.width = 80
-		m.height = 24
+		m.shell.Resize(80, 24)
 		out := m.View()
 		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 		if len(lines) != 24 {
@@ -49,8 +47,7 @@ func TestV080Audit_E1VerticalPadding(t *testing.T) {
 func TestV080Audit_E1StyleBleed(t *testing.T) {
 	m := newTimelineRunningModel()
 	for _, s := range AuditSizes {
-		m.width = s.W
-		m.height = s.H
+		m.shell.Resize(s.W, s.H)
 		out := m.View()
 		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
 		if len(lines) != s.H {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -11,136 +11,6 @@ import (
 	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
-type Region struct {
-	Width  int
-	Height int
-}
-
-type ShellLayout struct {
-	Context   Region
-	Workspace Region
-	Command   Region
-}
-
-func computeShellLayout(totalWidth, totalHeight int) ShellLayout {
-	width := max(72, totalWidth)
-	bodyHeight := max(1, totalHeight-5)
-	return ShellLayout{
-		Context:   Region{Width: width, Height: 1},
-		Workspace: Region{Width: width, Height: bodyHeight},
-		Command:   Region{Width: width, Height: 1},
-	}
-}
-
-// ShellColumnWidth is the fixed width reserved for the orientation label
-// in the operator ribbon. Actions always start at Column 19
-// (ShellColumnWidth + 2-char gutter + 1 space).
-const ShellColumnWidth = 16
-
-// ActionCategory defines the four semantic groups an action can belong to.
-// Categories are ordered by priority. Empty categories are omitted.
-type ActionCategory int
-
-const (
-	NavigationCategory ActionCategory = iota
-	ConfigurationCategory
-	OperationCategory
-	ApplicationCategory
-)
-
-// ActionID identifies an operator intent. The workspace exposes which actions
-// currently exist; the ribbon layer maps them to presentation.
-type ActionID int
-
-const (
-	ActionSelect ActionID = iota
-	ActionInspect
-	ActionSwitchView
-	ActionConfigureRequest
-	ActionRun
-	ActionCancel
-	ActionNextField
-	ActionSwitchMethod
-	ActionAdjustConcurrency
-	ActionNextHeader
-	ActionAddHeader
-	ActionDeleteHeader
-	ActionBack
-	ActionQuit
-	ActionConfirmQuit
-	ActionCtrlCQuit
-	ActionQQuit
-	ActionDismissCancel
-)
-
-// Action is a behavioral intent — not a presentation object.
-// The workspace produces actions; the ribbon derives presentation from them.
-type Action struct {
-	ID       ActionID
-	Category ActionCategory
-	Enabled  bool
-}
-
-// configItem represents a single configuration value in the Context region.
-// The contract is Identity, Value, Validity — presentation is a shell concern.
-type configItem struct {
-	Identity string
-	Value    string
-	Valid    bool
-}
-
-// ShellState is an immutable snapshot of the shell-level state produced once
-// per frame. Every shell renderer consumes this instead of reading model
-// fields independently, eliminating duplicate state lookups.
-type ShellState struct {
-	Orientation   string
-	Configuration []configItem
-	Actions       []Action
-}
-
-// actionBinding maps an operator intent (ActionID) to its presentation in the
-// operator ribbon. This is the single source of truth for shortcut-to-intent
-// mapping. All [Ctrl+R], [Esc], [Tab], etc. live here.
-type actionBinding struct {
-	Key      string
-	Label    string
-	Category ActionCategory
-}
-
-var actionBindings = map[ActionID]actionBinding{
-	ActionSelect:            {"↑↓", "Select", NavigationCategory},
-	ActionInspect:           {"Enter", "Inspect", NavigationCategory},
-	ActionSwitchView:        {"Tab", "Views", NavigationCategory},
-	ActionConfigureRequest:  {"e", "Request", ConfigurationCategory},
-	ActionRun:               {"Ctrl+R", "Run", OperationCategory},
-	ActionCancel:            {"Ctrl+X", "Cancel", OperationCategory},
-	ActionNextField:         {"Tab", "Next Field", ConfigurationCategory},
-	ActionSwitchMethod:      {"←→", "Method", ConfigurationCategory},
-	ActionAdjustConcurrency: {"↑↓", "Adjust", ConfigurationCategory},
-	ActionNextHeader:        {"Tab", "Next", ConfigurationCategory},
-	ActionAddHeader:         {"Ctrl+N", "Header", ConfigurationCategory},
-	ActionDeleteHeader:      {"Ctrl+D", "Delete", ConfigurationCategory},
-	ActionBack:              {"Esc", "Back", ApplicationCategory},
-	ActionQuit:              {"q", "Quit", ApplicationCategory},
-	ActionConfirmQuit:       {"Enter", "Quit", ApplicationCategory},
-	ActionCtrlCQuit:         {"Ctrl+C", "Quit", ApplicationCategory},
-	ActionQQuit:             {"q", "Quit", ApplicationCategory},
-	ActionDismissCancel:     {"Any", "Cancel", ApplicationCategory},
-}
-
-func (m Model) orientationLabel() string {
-	switch {
-	case m.dialog == dialogConfirmQuit:
-		return "QUIT"
-	case m.dialog == dialogRequest:
-		return "REQUEST"
-	case m.mode == modeInspect:
-		return "INSPECT"
-	default:
-		return "OBSERVE"
-	}
-}
-
 func (m Model) Actions() []Action {
 	switch {
 	case m.dialog == dialogConfirmQuit:
@@ -192,22 +62,8 @@ func (m Model) requestActions() []Action {
 		{ActionBack, ApplicationCategory, true},
 		{ActionRun, OperationCategory, true},
 	}
-	switch m.activeDomain {
-	case domainRequest:
-		domainActions = append([]Action{
-			{ActionNextField, ConfigurationCategory, true},
-			{ActionSwitchMethod, ConfigurationCategory, true},
-		}, domainActions...)
-	case domainPayload:
-		domainActions = append([]Action{
-			{ActionNextField, ConfigurationCategory, true},
-			{ActionAddHeader, ConfigurationCategory, true},
-			{ActionDeleteHeader, ConfigurationCategory, true},
-		}, domainActions...)
-	case domainExec:
-		domainActions = append([]Action{
-			{ActionAdjustConcurrency, ConfigurationCategory, true},
-		}, domainActions...)
+	if d, ok := domainRegistry[m.activeDomain]; ok {
+		domainActions = append(d.Actions(m), domainActions...)
 	}
 	return domainActions
 }
@@ -227,18 +83,19 @@ func (m Model) Configuration() []configItem {
 
 func (m Model) ShellState() ShellState {
 	return ShellState{
-		Orientation:   m.orientationLabel(),
+		Orientation:   orientationLabel(m),
 		Configuration: m.Configuration(),
 		Actions:       m.Actions(),
 	}
 }
 
 func (m Model) View() string {
-	if m.width == 0 {
+	w, h := m.shell.Dimensions()
+	if w == 0 {
 		return "Pulse is starting..."
 	}
 
-	layout := computeShellLayout(m.width, m.height)
+	layout := m.shell.Layout()
 	state := m.ShellState()
 
 	var sb strings.Builder
@@ -246,13 +103,13 @@ func (m Model) View() string {
 	sb.WriteString("\n")
 	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Context.Width)))
 	sb.WriteString("\n")
-	sb.WriteString(m.renderCurrentSurface(layout.Workspace))
+	sb.WriteString(m.resolveSurface().Render(layout.Workspace))
 	sb.WriteString("\n")
 	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Command.Width)))
 	sb.WriteString("\n")
 	sb.WriteString(m.renderRibbon(state, layout.Command.Width))
 
-	return styleBase.Width(layout.Context.Width).Height(m.height).Render(sb.String())
+	return styleBase.Width(layout.Context.Width).Height(h).Render(sb.String())
 }
 
 func (m Model) renderCurrentSurface(region Region) string {
@@ -369,16 +226,28 @@ func accentOrMuted(name string, active bool) string {
 	return styleMuted.Render(name)
 }
 
-func (m Model) renderRequestDomain(b *strings.Builder) {
+func (m Model) renderRequest(region Region) string {
+	var b strings.Builder
+	b.WriteString(identityCell("REQUEST", false))
 	b.WriteString("\n")
-	b.WriteString(accentOrMuted("Request", m.activeDomain == domainRequest))
+	b.WriteString(m.renderRequestDomain())
+	b.WriteString(m.renderPayloadDomain())
+	b.WriteString(m.renderRunDomain())
+
+	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
+}
+
+func (m Model) renderRequestDomain() string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(accentOrMuted("Request", m.activeDomain == DomainRequest))
 	b.WriteString("\n")
 
 	methods := runconfig.AllowedMethods()
 	var methodLine string
 	for i, method := range methods {
 		sel := i == m.methodIndex
-		focus := m.activeDomain == domainRequest && m.requestField == reqFieldMethod
+		focus := m.activeDomain == DomainRequest && m.requestField == reqFieldMethod
 		if sel && focus {
 			methodLine += lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Background(lipgloss.Color(colorDark)).Render(" " + method + " ")
 		} else if sel {
@@ -389,7 +258,7 @@ func (m Model) renderRequestDomain(b *strings.Builder) {
 	}
 
 	methodLabel := "Method"
-	if m.activeDomain == domainRequest && m.requestField == reqFieldMethod {
+	if m.activeDomain == DomainRequest && m.requestField == reqFieldMethod {
 		methodLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("Method")
 	} else {
 		methodLabel = styleMuted.Render("Method")
@@ -398,20 +267,23 @@ func (m Model) renderRequestDomain(b *strings.Builder) {
 	b.WriteString(fmt.Sprintf("  %s\n    %s\n", methodLabel, methodLine))
 
 	urlLabel := "URL"
-	if m.activeDomain == domainRequest && m.requestField == reqFieldURL {
+	if m.activeDomain == DomainRequest && m.requestField == reqFieldURL {
 		urlLabel = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Render("URL")
 	} else {
 		urlLabel = styleMuted.Render("URL")
 	}
 	b.WriteString(fmt.Sprintf("  %s\n    %s\n", urlLabel, m.urlInput.View()))
+
+	return b.String()
 }
 
-func (m Model) renderPayloadDomain(b *strings.Builder) {
+func (m Model) renderPayloadDomain() string {
+	var b strings.Builder
 	b.WriteString("\n")
-	b.WriteString(accentOrMuted("Payload", m.activeDomain == domainPayload))
+	b.WriteString(accentOrMuted("Payload", m.activeDomain == DomainPayload))
 	b.WriteString("\n")
 
-	headersActive := m.activeDomain == domainPayload && m.selectedHead != bodyFocus
+	headersActive := m.activeDomain == DomainPayload && m.selectedHead != bodyFocus
 	b.WriteString(accentOrMuted("  HEADERS  ctrl+n add  ctrl+d remove", headersActive))
 	b.WriteString("\n")
 
@@ -429,7 +301,7 @@ func (m Model) renderPayloadDomain(b *strings.Builder) {
 		}
 	}
 
-	bodyActive := m.activeDomain == domainPayload && m.selectedHead == bodyFocus
+	bodyActive := m.activeDomain == DomainPayload && m.selectedHead == bodyFocus
 	bodyLen := len(m.bodyInput.Value())
 	bodyLabel := "  BODY"
 	if bodyLen > 0 {
@@ -438,15 +310,18 @@ func (m Model) renderPayloadDomain(b *strings.Builder) {
 	b.WriteString(accentOrMuted(bodyLabel, bodyActive))
 	b.WriteString("\n")
 	b.WriteString("  " + m.bodyInput.View())
+
+	return b.String()
 }
 
-func (m Model) renderExecDomain(b *strings.Builder) {
+func (m Model) renderRunDomain() string {
+	var b strings.Builder
 	b.WriteString("\n")
-	b.WriteString(accentOrMuted("Execution", m.activeDomain == domainExec))
+	b.WriteString(accentOrMuted("Execution", m.activeDomain == DomainExec))
 	b.WriteString("\n")
 
 	ccText := strings.TrimSpace(m.ccInput.View())
-	active := m.activeDomain == domainExec
+	active := m.activeDomain == DomainExec
 	ccLabel := accentOrMuted("  Concurrency", active)
 	if active {
 		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccText, runconfig.MaxConcurrency))
@@ -454,18 +329,8 @@ func (m Model) renderExecDomain(b *strings.Builder) {
 		ccVal := lipgloss.NewStyle().Foreground(lipgloss.Color(colorText)).Render(ccText)
 		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccVal, runconfig.MaxConcurrency))
 	}
-}
 
-func (m Model) renderRequest(region Region) string {
-	var b strings.Builder
-	b.WriteString(identityCell("REQUEST", false))
-	b.WriteString("\n")
-
-	m.renderRequestDomain(&b)
-	m.renderPayloadDomain(&b)
-	m.renderExecDomain(&b)
-
-	return styleBase.Copy().Width(region.Width).Height(region.Height).Render(b.String())
+	return b.String()
 }
 
 func (m Model) renderRibbon(state ShellState, width int) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -15,8 +15,7 @@ func contains(t *testing.T, s, substr string) bool {
 
 func TestView_Idle(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	out := m.View()
 	if !contains(t, out, "GET") {
 		t.Fatal("View should contain method")
@@ -28,8 +27,7 @@ func TestView_Idle(t *testing.T) {
 
 func TestView_Running(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	m.running = true
 	m.status = "RUNNING"
 	m.startedAt = time.Now().Add(-2 * time.Second)
@@ -51,8 +49,7 @@ func TestView_Running(t *testing.T) {
 
 func TestRenderReady(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	out := m.renderReady(Region{Width: 100, Height: 26})
 	if !contains(t, out, "OBSERVE") {
 		t.Fatal("Ready should show identity")
@@ -73,8 +70,7 @@ func TestRenderReady(t *testing.T) {
 
 func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 
 	out := m.View()
 	if !contains(t, out, "OBSERVE") {
@@ -90,7 +86,7 @@ func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 
 func TestRenderTopBar_ShowsMethodAndURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderTopBar(m.ShellState(), 100)
 	if !contains(t, out, "GET") {
 		t.Fatal("top bar should contain method")
@@ -102,7 +98,7 @@ func TestRenderTopBar_ShowsMethodAndURL(t *testing.T) {
 
 func TestRenderTopBar_ShowsPayloadSummary(t *testing.T) {
 	m := NewModel()
-	m.width = 120
+	m.shell.Resize(120, 30)
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
 	m.headers[0].Value.SetValue("application/json")
@@ -119,7 +115,7 @@ func TestRenderTopBar_ShowsPayloadSummary(t *testing.T) {
 
 func TestRenderTopBar_ShowsCC(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderTopBar(m.ShellState(), 100)
 	if !contains(t, out, "CC") {
 		t.Fatal("top bar should show CC")
@@ -128,7 +124,7 @@ func TestRenderTopBar_ShowsCC(t *testing.T) {
 
 func TestRenderTopBar_QueryTruncation(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.urlInput.SetValue("https://api.example.com/users?page=1")
 	out := m.renderTopBar(m.ShellState(), 100)
 	if contains(t, out, "?page=1") {
@@ -141,7 +137,7 @@ func TestRenderTopBar_QueryTruncation(t *testing.T) {
 
 func TestMetricsString(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.summary.Total = 50
 	m.summary.Successes = 45
@@ -168,7 +164,7 @@ func TestMetricsString(t *testing.T) {
 
 func TestMetricsString_Zero(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.metricsString()
 	if out != "" {
 		t.Fatal("idle metrics with no results should be empty")
@@ -177,7 +173,7 @@ func TestMetricsString_Zero(t *testing.T) {
 
 func TestMetricsString_HiddenWhenIdle(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = false
 	m.summary.Total = 0
 	m.summary.SuccessRate = 0
@@ -197,7 +193,7 @@ func TestMetricsString_HiddenWhenIdle(t *testing.T) {
 
 func TestMetricsString_Values(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.summary.Total = 10
 	m.summary.Successes = 10
@@ -219,7 +215,7 @@ func TestMetricsString_Values(t *testing.T) {
 
 func TestMetricsString_RunningRPS(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.elapsed = 2 * time.Second
 	m.summary.Total = 100
@@ -237,7 +233,7 @@ func TestMetricsString_RunningRPS(t *testing.T) {
 
 func TestMetricsString_RunningEmpty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.elapsed = 100 * time.Millisecond
 	m.summary.Total = 0
@@ -257,7 +253,7 @@ func TestMetricsString_RunningEmpty(t *testing.T) {
 
 func TestRenderRibbon_Normal(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[↑↓] Select") {
@@ -270,7 +266,7 @@ func TestRenderRibbon_Normal(t *testing.T) {
 
 func TestRenderRibbon_Ready(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[e] Request") {
 		t.Fatal("ready ribbon should show [e] Request")
@@ -294,7 +290,7 @@ func TestRenderRibbon_Ready(t *testing.T) {
 
 func TestRenderRibbon_RunningEmpty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "Ctrl+X") {
@@ -310,7 +306,7 @@ func TestRenderRibbon_RunningEmpty(t *testing.T) {
 
 func TestRenderRibbon_RunningWithResults(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderRibbon(m.ShellState(), 100)
@@ -327,9 +323,9 @@ func TestRenderRibbon_RunningWithResults(t *testing.T) {
 
 func TestRenderRibbon_RequestDialog(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
 		t.Fatal("request ribbon should show [Esc] Back")
@@ -344,9 +340,9 @@ func TestRenderRibbon_RequestDialog(t *testing.T) {
 
 func TestRenderRibbon_RequestExecDialog(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
 		t.Fatal("request exec ribbon should show [Esc] Back")
@@ -358,7 +354,7 @@ func TestRenderRibbon_RequestExecDialog(t *testing.T) {
 
 func TestRenderRibbon_Inspecting(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.mode = modeInspect
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Esc] Back") {
@@ -371,7 +367,7 @@ func TestRenderRibbon_Inspecting(t *testing.T) {
 
 func TestRenderRibbon_QuitConfirm(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogConfirmQuit
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "Quit") {
@@ -384,7 +380,7 @@ func TestRenderRibbon_QuitConfirm(t *testing.T) {
 
 func TestRenderTimeline_Identity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
@@ -399,7 +395,7 @@ func TestRenderTimeline_Identity(t *testing.T) {
 
 func TestRenderTimeline_Empty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderTimeline(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Timeline") {
 		t.Fatal("empty timeline should show Timeline identity")
@@ -411,7 +407,7 @@ func TestRenderTimeline_Empty(t *testing.T) {
 
 func TestRenderTimeline_Rows(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond},
 		{Status: 404, Latency: 50 * time.Millisecond},
@@ -433,7 +429,7 @@ func TestRenderTimeline_Rows(t *testing.T) {
 
 func TestRenderLogs_Identity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond, RequestMethod: "GET", RequestURL: "https://example.com/api"},
 	}
@@ -448,7 +444,7 @@ func TestRenderLogs_Identity(t *testing.T) {
 
 func TestRenderLogs_Empty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderLogs(Region{Width: 94, Height: 20})
 	if !contains(t, out, "Logs") {
 		t.Fatal("empty logs should show Logs identity")
@@ -460,7 +456,7 @@ func TestRenderLogs_Empty(t *testing.T) {
 
 func TestRenderLogs_Rows(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.urlInput.SetValue("https://example.com/api")
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond, RequestMethod: "GET", RequestURL: "https://example.com/api"},
@@ -489,7 +485,7 @@ func TestRenderLogs_Rows(t *testing.T) {
 
 func TestRenderInspect_Identity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.selected = 0
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond},
@@ -506,7 +502,7 @@ func TestRenderInspect_Identity(t *testing.T) {
 
 func TestRenderInspect_NoSelection(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderInspect(Region{Width: 40, Height: 20})
 	if !contains(t, out, "No result selected.") {
 		t.Fatal("inspector with no selection should show 'No result selected.'")
@@ -515,7 +511,7 @@ func TestRenderInspect_NoSelection(t *testing.T) {
 
 func TestRenderInspect_WithResult(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.selected = 0
 	m.results = []model.Result{
 		{
@@ -545,7 +541,7 @@ func TestRenderInspect_WithResult(t *testing.T) {
 
 func TestRenderInspect_NoMetrics(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.selected = 0
 	m.results = []model.Result{
@@ -566,7 +562,7 @@ func TestRenderInspect_NoMetrics(t *testing.T) {
 
 func TestRenderInspect_WithError(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.selected = 0
 	m.results = []model.Result{
 		{
@@ -587,7 +583,7 @@ func TestRenderInspect_WithError(t *testing.T) {
 
 func TestRenderInspect_NoHeaders(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.selected = 0
 	m.results = []model.Result{
 		{
@@ -604,7 +600,7 @@ func TestRenderInspect_NoHeaders(t *testing.T) {
 
 func TestRenderInspect_NoBody(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.selected = 0
 	m.results = []model.Result{
 		{
@@ -703,7 +699,7 @@ func TestTruncate(t *testing.T) {
 
 func TestRenderTimeline_RunningEmpty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.status = "RUNNING"
 
@@ -718,7 +714,7 @@ func TestRenderTimeline_RunningEmpty(t *testing.T) {
 
 func TestRenderTimeline_IdleNoURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = false
 	m.urlInput.SetValue("")
 
@@ -733,7 +729,7 @@ func TestRenderTimeline_IdleNoURL(t *testing.T) {
 
 func TestRenderTimeline_IdleWithURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = false
 	m.urlInput.SetValue("https://example.com/api")
 
@@ -748,7 +744,7 @@ func TestRenderTimeline_IdleWithURL(t *testing.T) {
 
 func TestRenderLogs_RunningEmpty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.status = "RUNNING"
 
@@ -763,7 +759,7 @@ func TestRenderLogs_RunningEmpty(t *testing.T) {
 
 func TestRenderLogs_IdleNoURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = false
 	m.urlInput.SetValue("")
 
@@ -778,7 +774,7 @@ func TestRenderLogs_IdleNoURL(t *testing.T) {
 
 func TestRenderLogs_IdleWithURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = false
 	m.urlInput.SetValue("https://example.com/api")
 
@@ -793,8 +789,7 @@ func TestRenderLogs_IdleWithURL(t *testing.T) {
 
 func TestView_WidthMinClamp(t *testing.T) {
 	m := NewModel()
-	m.width = 40
-	m.height = 30
+	m.shell.Resize(40, 30)
 
 	out := m.View()
 	if !contains(t, out, "GET") {
@@ -804,8 +799,7 @@ func TestView_WidthMinClamp(t *testing.T) {
 
 func TestView_PayloadNotShown(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 
 	out := m.View()
 	if contains(t, out, "HEADERS") {
@@ -818,9 +812,9 @@ func TestView_PayloadNotShown(t *testing.T) {
 
 func TestRenderPayload_Identity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
@@ -846,9 +840,9 @@ func TestRenderPayload_Identity(t *testing.T) {
 
 func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 
 	out := m.renderRequest(Region{Width: 96, Height: 20})
@@ -862,9 +856,9 @@ func TestRenderPayload_NoHeadersConfigured(t *testing.T) {
 
 func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headers = append(m.headers, newHeaderRow())
 	m.headers[0].Key.SetValue("Content-Type")
@@ -881,9 +875,9 @@ func TestRenderPayload_EmptyBodyPlaceholder(t *testing.T) {
 
 func TestRenderRequest_Identity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 	out := m.renderRequest(Region{Width: 100, Height: 20})
@@ -903,9 +897,9 @@ func TestRenderRequest_Identity(t *testing.T) {
 
 func TestRenderRequest_ExecutionIdentity(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.setConcurrency(7)
 	out := m.renderRequest(Region{Width: 100, Height: 20})
 	if !contains(t, out, "REQUEST") {
@@ -921,9 +915,9 @@ func TestRenderRequest_ExecutionIdentity(t *testing.T) {
 
 func TestRenderEndpoint_Focused(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainRequest
+	m.activeDomain = DomainRequest
 	m.requestField = reqFieldURL
 	m.urlInput.Focus()
 	m.urlInput.SetValue("https://example.com/api")
@@ -942,9 +936,9 @@ func TestRenderEndpoint_Focused(t *testing.T) {
 
 func TestRenderConcurrency_Focused(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
+	m.activeDomain = DomainExec
 	m.ccInput.Focus()
 	m.setConcurrency(7)
 
@@ -962,9 +956,9 @@ func TestRenderConcurrency_Focused(t *testing.T) {
 
 func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusKey
 	m.headers = append(m.headers, newHeaderRow())
@@ -989,9 +983,9 @@ func TestRenderPayload_HeaderKeyFocus(t *testing.T) {
 
 func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = 0
 	m.headerSubfocus = subfocusValue
 	m.headers = append(m.headers, newHeaderRow())
@@ -1016,9 +1010,9 @@ func TestRenderPayload_HeaderValueFocus(t *testing.T) {
 
 func TestRenderPayload_BodyFocus(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = bodyFocus
 	m.bodyInput.Focus()
 	m.bodyInput.SetValue(`{"key": "value"}`)
@@ -1035,8 +1029,7 @@ func TestRenderPayload_BodyFocus(t *testing.T) {
 
 func TestRenderCurrentSurface_DispatchesToSurface(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 
 	region := Region{Width: 100, Height: 26}
 
@@ -1049,8 +1042,7 @@ func TestRenderCurrentSurface_DispatchesToSurface(t *testing.T) {
 
 func TestRenderWorkspace_InspectorDrillDown(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	m.mode = modeInspect
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond,
@@ -1073,7 +1065,7 @@ func TestRenderWorkspace_InspectorDrillDown(t *testing.T) {
 
 func TestRenderTimeline_Rows_Selected(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{
 		{Status: 200, Latency: 100 * time.Millisecond},
 	}
@@ -1091,9 +1083,9 @@ func TestRenderTimeline_Rows_Selected(t *testing.T) {
 
 func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.headers = append(m.headers, newHeaderRow(), newHeaderRow(), newHeaderRow())
 	m.headers[0].Key.SetValue("Authorization")
 	m.headers[0].Value.SetValue("Bearer token")
@@ -1116,9 +1108,9 @@ func TestRenderPayload_SelectedRowVisible(t *testing.T) {
 
 func TestRenderPayload_BodyFocusColor(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	m.selectedHead = bodyFocus
 	m.headers = append(m.headers, newHeaderRow())
 
@@ -1130,9 +1122,9 @@ func TestRenderPayload_BodyFocusColor(t *testing.T) {
 
 func TestRenderRibbon_RequestPayloadDialog(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
+	m.activeDomain = DomainPayload
 	out := m.renderRibbon(m.ShellState(), 100)
 	if !contains(t, out, "[Tab] Next") {
 		t.Fatal("request payload ribbon should show [Tab] Next")
@@ -1150,8 +1142,7 @@ func TestRenderRibbon_RequestPayloadDialog(t *testing.T) {
 
 func TestConfirmQuit_PreservesWorkspace(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	m.running = true
 	m.dialog = dialogConfirmQuit
 
@@ -1192,111 +1183,111 @@ func TestPayloadSummary(t *testing.T) {
 
 func TestOrientationLabel_Ready(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	m.shell.Resize(100, 24)
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("ready orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_WithResults(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("results orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_RunningEmpty(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("running empty orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_RunningWithResults(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("running+results orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_LogsView(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.view = viewLogs
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("logs view orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_RunningLogsView(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.view = viewLogs
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
-	if got := m.orientationLabel(); got != "OBSERVE" {
+	if got := orientationLabel(m); got != "OBSERVE" {
 		t.Fatalf("running+logs orientationLabel = %q, want OBSERVE", got)
 	}
 }
 
 func TestOrientationLabel_RequestDialog(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	if got := m.orientationLabel(); got != "REQUEST" {
+	if got := orientationLabel(m); got != "REQUEST" {
 		t.Fatalf("request dialog orientationLabel = %q, want REQUEST", got)
 	}
 }
 
 func TestOrientationLabel_ExecDomain(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainExec
-	if got := m.orientationLabel(); got != "REQUEST" {
+	m.activeDomain = DomainExec
+	if got := orientationLabel(m); got != "REQUEST" {
 		t.Fatalf("request dialog (exec) orientationLabel = %q, want REQUEST", got)
 	}
 }
 
 func TestOrientationLabel_PayloadDomain(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogRequest
-	m.activeDomain = domainPayload
-	if got := m.orientationLabel(); got != "REQUEST" {
+	m.activeDomain = DomainPayload
+	if got := orientationLabel(m); got != "REQUEST" {
 		t.Fatalf("request dialog (payload) orientationLabel = %q, want REQUEST", got)
 	}
 }
 
 func TestOrientationLabel_InspectMode(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.mode = modeInspect
-	if got := m.orientationLabel(); got != "INSPECT" {
+	if got := orientationLabel(m); got != "INSPECT" {
 		t.Fatalf("inspect mode orientationLabel = %q, want INSPECT", got)
 	}
 }
 
 func TestOrientationLabel_QuitDialog(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.dialog = dialogConfirmQuit
-	if got := m.orientationLabel(); got != "QUIT" {
+	if got := orientationLabel(m); got != "QUIT" {
 		t.Fatalf("quit dialog orientationLabel = %q, want QUIT", got)
 	}
 }
 
 func TestRenderRibbon_ShellColumnWidth(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderRibbon(m.ShellState(), 100)
 	// Shell column must contain orientation label with accent anchor prefix.
 	// Format: "│ OBSERVE      " (anchor + space + 7-char label padded to 14 = 16).
@@ -1311,7 +1302,7 @@ func TestRenderRibbon_ShellColumnWidth(t *testing.T) {
 
 func TestRenderRibbon_EmptyGroupsOmitted(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderRibbon(m.ShellState(), 100)
 	// Ready state has no Navigation commands — must not render "[↑↓]" or "[Enter] Inspect".
 	if contains(t, out, "[↑↓]") {
@@ -1321,7 +1312,7 @@ func TestRenderRibbon_EmptyGroupsOmitted(t *testing.T) {
 
 func TestRenderRibbon_CategoryOrder(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	out := m.renderRibbon(m.ShellState(), 100)
 	// With results: Navigation → Configuration → Operation → Application.
@@ -1341,7 +1332,7 @@ func TestRenderRibbon_CategoryOrder(t *testing.T) {
 
 func TestRenderRibbon_WithinGroupSeparator(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderRibbon(m.ShellState(), 100)
 	// Ready state: [e] Request in Configuration group.
 	if !contains(t, out, "[e] Request") {
@@ -1351,7 +1342,7 @@ func TestRenderRibbon_WithinGroupSeparator(t *testing.T) {
 
 func TestRenderRibbon_BetweenGroupSeparator(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderRibbon(m.ShellState(), 100)
 	// Ready state: Configuration group followed by Operation group.
 	// Must have 4-space gap between groups.
@@ -1371,23 +1362,23 @@ func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
 
 	// renderReady
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	if contains(t, m.renderReady(region), "─") {
 		t.Fatal("renderReady must not render shell separators")
 	}
 
 	// renderRequest
 	m2 := NewModel()
-	m2.width = 100
+	m2.shell.Resize(100, 24)
 	m2.dialog = dialogRequest
-	m2.activeDomain = domainRequest
+	m2.activeDomain = DomainRequest
 	if contains(t, m2.renderRequest(region), "─") {
 		t.Fatal("renderRequest must not render shell separators")
 	}
 
 	// renderTimeline
 	m3 := NewModel()
-	m3.width = 100
+	m3.shell.Resize(100, 24)
 	m3.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	if contains(t, m3.renderTimeline(region), "─") {
 		t.Fatal("renderTimeline must not render shell separators")
@@ -1395,7 +1386,7 @@ func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
 
 	// renderLogs
 	m4 := NewModel()
-	m4.width = 100
+	m4.shell.Resize(100, 24)
 	m4.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	if contains(t, m4.renderLogs(region), "─") {
 		t.Fatal("renderLogs must not render shell separators")
@@ -1403,7 +1394,7 @@ func TestShellInvariant_WorkspaceNoSeparators(t *testing.T) {
 
 	// renderInspect
 	m5 := NewModel()
-	m5.width = 100
+	m5.shell.Resize(100, 24)
 	m5.selected = 0
 	m5.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	if contains(t, m5.renderInspect(Region{Width: 40, Height: 20}), "─") {
@@ -1420,7 +1411,7 @@ func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
 	shortcutPatterns := []string{"Ctrl+", "[Esc]", "[Tab]", "[Enter]", "[↑↓]", "[←→]", "[q]", "[e]"}
 
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	out := m.renderCurrentSurface(region)
 	for _, pat := range shortcutPatterns {
 		if contains(t, out, pat) {
@@ -1430,9 +1421,9 @@ func TestShellInvariant_WorkspaceNoShortcuts(t *testing.T) {
 
 	// Verify the REQUEST surface also follows this rule.
 	m2 := NewModel()
-	m2.width = 100
+	m2.shell.Resize(100, 24)
 	m2.dialog = dialogRequest
-	m2.activeDomain = domainRequest
+	m2.activeDomain = DomainRequest
 	for _, pat := range shortcutPatterns {
 		if contains(t, m2.renderRequest(region), pat) {
 			t.Fatalf("Request surface must not contain %q", pat)
@@ -1454,7 +1445,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 	}
 
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 
 	// Idle
 	if !hasLabel(m.renderRibbon(m.ShellState(), 100)) {
@@ -1463,7 +1454,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 
 	// Running empty
 	m2 := NewModel()
-	m2.width = 100
+	m2.shell.Resize(100, 24)
 	m2.running = true
 	if !hasLabel(m2.renderRibbon(m2.ShellState(), 100)) {
 		t.Fatal("ribbon must show orientation label when running empty")
@@ -1471,7 +1462,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 
 	// With results
 	m3 := NewModel()
-	m3.width = 100
+	m3.shell.Resize(100, 24)
 	m3.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 	if !hasLabel(m3.renderRibbon(m3.ShellState(), 100)) {
 		t.Fatal("ribbon must show orientation label with results")
@@ -1479,7 +1470,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 
 	// Inspect mode
 	m4 := NewModel()
-	m4.width = 100
+	m4.shell.Resize(100, 24)
 	m4.mode = modeInspect
 	if !hasLabel(m4.renderRibbon(m4.ShellState(), 100)) {
 		t.Fatal("ribbon must show orientation label in inspect mode")
@@ -1487,7 +1478,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 
 	// Request dialog
 	m5 := NewModel()
-	m5.width = 100
+	m5.shell.Resize(100, 24)
 	m5.dialog = dialogRequest
 	if !hasLabel(m5.renderRibbon(m5.ShellState(), 100)) {
 		t.Fatal("ribbon must show orientation label in request dialog")
@@ -1495,7 +1486,7 @@ func TestShellInvariant_RibbonHasOrientation(t *testing.T) {
 
 	// ConfirmQuit dialog
 	m6 := NewModel()
-	m6.width = 100
+	m6.shell.Resize(100, 24)
 	m6.dialog = dialogConfirmQuit
 	if !hasLabel(m6.renderRibbon(m6.ShellState(), 100)) {
 		t.Fatal("ribbon must show orientation label in quit dialog")
@@ -1514,19 +1505,19 @@ func TestShellInvariant_ActionsAreIntents(t *testing.T) {
 		func() []Action {
 			m := NewModel()
 			m.dialog = dialogRequest
-			m.activeDomain = domainRequest
+			m.activeDomain = DomainRequest
 			return m.Actions()
 		},
 		func() []Action {
 			m := NewModel()
 			m.dialog = dialogRequest
-			m.activeDomain = domainExec
+			m.activeDomain = DomainExec
 			return m.Actions()
 		},
 		func() []Action {
 			m := NewModel()
 			m.dialog = dialogRequest
-			m.activeDomain = domainPayload
+			m.activeDomain = DomainPayload
 			return m.Actions()
 		},
 		func() []Action { m := NewModel(); m.mode = modeInspect; return m.Actions() },
@@ -1553,8 +1544,7 @@ func TestShellInvariant_ActionsAreIntents(t *testing.T) {
 // separators, and they appear exactly twice (context separator, ribbon separator).
 func TestShellInvariant_ViewOwnsSeparators(t *testing.T) {
 	m := NewModel()
-	m.width = 100
-	m.height = 30
+	m.shell.Resize(100, 30)
 	out := m.View()
 	if !contains(t, out, "─") {
 		t.Fatal("View must render shell separators")
@@ -1567,7 +1557,7 @@ func TestShellInvariant_ViewOwnsSeparators(t *testing.T) {
 
 func TestShellState_ContainsOrientation(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	s := m.ShellState()
 	if s.Orientation == "" {
 		t.Fatal("ShellState.Orientation must not be empty")
@@ -1576,7 +1566,7 @@ func TestShellState_ContainsOrientation(t *testing.T) {
 
 func TestShellState_ContainsConfiguration(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	s := m.ShellState()
 	if len(s.Configuration) == 0 {
 		t.Fatal("ShellState.Configuration must not be empty")
@@ -1594,7 +1584,7 @@ func TestShellState_ContainsConfiguration(t *testing.T) {
 
 func TestShellState_ContainsActions(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	s := m.ShellState()
 	if len(s.Actions) == 0 {
 		t.Fatal("ShellState.Actions must not be empty")
@@ -1603,7 +1593,7 @@ func TestShellState_ContainsActions(t *testing.T) {
 
 func TestShellState_QueryTruncated(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.urlInput.SetValue("https://api.example.com/users?page=1")
 	s := m.ShellState()
 	url := ""
@@ -1619,7 +1609,7 @@ func TestShellState_QueryTruncated(t *testing.T) {
 
 func TestShellState_UpdatesWithState(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.running = true
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
 
@@ -1635,7 +1625,7 @@ func TestShellState_UpdatesWithState(t *testing.T) {
 
 func TestConfiguration_MethodAndURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	cfg := m.Configuration()
 	if len(cfg) < 3 {
 		t.Fatal("Configuration should have at least 3 items (Method, URL, CC)")
@@ -1653,7 +1643,7 @@ func TestConfiguration_MethodAndURL(t *testing.T) {
 
 func TestConfiguration_InvalidURL(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.urlInput.SetValue("")
 	cfg := m.Configuration()
 	for _, c := range cfg {
@@ -1665,7 +1655,7 @@ func TestConfiguration_InvalidURL(t *testing.T) {
 
 func TestConfiguration_PayloadIncluded(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	m.headers = append(m.headers, newHeaderRow())
 	m.bodyInput.SetValue("{}")
 	cfg := m.Configuration()
@@ -1682,7 +1672,7 @@ func TestConfiguration_PayloadIncluded(t *testing.T) {
 
 func TestConfiguration_PayloadExcluded(t *testing.T) {
 	m := NewModel()
-	m.width = 100
+	m.shell.Resize(100, 24)
 	cfg := m.Configuration()
 	for _, c := range cfg {
 		if c.Identity == "Payload" {

--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -1,0 +1,57 @@
+package tui
+
+// ViewType identifies which presentation surface the Workspace shows for
+// the OBSERVE orientation.
+type ViewType int
+
+const (
+	TimelineView ViewType = iota
+	LogsView
+)
+
+// Workspace is the composition unit. A Workspace composes Views, a View
+// composes Regions, a Region hosts Surfaces. Workspace is owned by Shell.
+type Workspace struct {
+	mode   mode
+	dialog dialog
+	view   ViewType
+
+	surface Surface
+}
+
+// NewWorkspace creates the default Workspace (OBSERVE/Timeline).
+func NewWorkspace() Workspace {
+	return Workspace{
+		mode:   modeObserve,
+		dialog: dialogNone,
+		view:   TimelineView,
+	}
+}
+
+// Orientation returns the current orientation string based on workspace state.
+func (w Workspace) Orientation() string {
+	switch {
+	case w.dialog == dialogConfirmQuit:
+		return "QUIT"
+	case w.dialog == dialogRequest:
+		return "REQUEST"
+	case w.mode == modeInspect:
+		return "INSPECT"
+	default:
+		return "OBSERVE"
+	}
+}
+
+// IsRequesting returns true when the REQUEST dialog is active.
+func (w Workspace) IsRequesting() bool { return w.dialog == dialogRequest }
+
+// IsInspecting returns true when INSPECT mode is active.
+func (w Workspace) IsInspecting() bool { return w.mode == modeInspect }
+
+// IsObserving returns true when in the default OBSERVE mode with no dialog.
+func (w Workspace) IsObserving() bool {
+	return w.mode == modeObserve && w.dialog == dialogNone
+}
+
+// IsQuitting returns true when the confirm-quit dialog is shown.
+func (w Workspace) IsQuitting() bool { return w.dialog == dialogConfirmQuit }


### PR DESCRIPTION
Shell, Workspace, View, Region, Surface, and Domain are now defined as first-class types. All 199 tests pass. Race clean.

### Six foundational concepts introduced

Shell:
  Shell struct owns geometry (width, height) via Resize/Dimensions.
  ShellLayout divides terminal into Context, Workspace, Command regions.
  ActionID/ActionCategory/Action types and actionBindings registry.
  ShellState snapshot per frame. orientationLabel, computeShellLayout.

Workspace:
  Workspace struct with mode/dialog/view fields.
  ViewType enum (TimelineView, LogsView). NewWorkspace constructor.
  Convenience methods: Orientation, IsRequesting, IsInspecting,
  IsObserving, IsQuitting.

View:
  ViewType added to workspace.go (TimelineView, LogsView).
  Foundation for View composition (completes v0.9.1).

Region:
  Region struct (Width, Height). RegionType enum
  (ContextRegion, WorkspaceRegion, CommandRegion).
  Used by ShellLayout and all surface renderers.

Surface:
  Surface interface (Render(Region) string). surfaceFunc adapter.
  resolveSurface() dispatches to renderRequest/renderInspect/
  renderReady/renderTimeline/renderLogs based on Model state.

Domain:
  Domain interface (Actions(m Model) []Action).
  DomainType enum (Request, Payload, Exec).
  Three implementations (RequestDomain, PayloadDomain, RunDomain).
  domainRegistry mapping.

### Constitutional finalization

C1: Domain Purity (law: Domain never owns rendering):
  Removed Render from Domain interface. Domain now only defines
  Actions(). Rendering code moved from domain.go to view.go
  as Model methods (renderRequestDomain, renderPayloadDomain,
  renderRunDomain). domain.go has zero imports, no lipgloss,
  no fmt, no strings. Verified: no rendering concern remains
  in Domain.

C2: Recovery Contract (law: no destructive 1-key action):
  q and ctrl+c in idle state no longer quit immediately.
  Both now always open the confirmation dialog, matching the
  existing running and inspect behaviour. tea.Quit centralized
  in handleConfirmQuitKey (single occurrence). Verified:
  no single-key destructive path exists.

### Remaining debt (v0.9.1)
  - Workspace normalization (eliminate duplicated mode/dialog/view on Model)
  - View composition (Views compose Regions)
  - Region hosting (Regions host Surfaces)
  - Surface normalization (replace function adapters)
  - Shell ownership completion (move top bar/ribbon to Shell)
  - Model decomposition
  - Interaction grammar normalization

Verification:
  go fmt ./...: clean
  go vet ./...: clean
  go build ./...: clean
  go test -count=1 ./...: all 9 packages pass
  go test -race ./internal/tui/: clean (5.17s)
  domain.go lipgloss import: removed
  tea.Quit count: 1 (handleConfirmQuitKey only)