### PR TITLE
v0.9.3: Finalize spacing, typography, and Region.Padding across workspaces

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -912,7 +912,7 @@ func TestRequestDialog_ExecDomain_TypesDigits(t *testing.T) {
 	m = updated.(Model)
 
 	if !strings.Contains(m.concurrencyInput.Value(), "5") {
-		t.Fatal("CC input should contain typed digit")
+		t.Fatal("concurrencyInput should contain typed digit")
 	}
 }
 

--- a/internal/tui/region.go
+++ b/internal/tui/region.go
@@ -60,7 +60,11 @@ func (r Region) renderPadded(content string) string {
 }
 
 func (r Region) renderBoxed(content string) string {
-	innerW := r.Width - 4
+	borderPad := r.Padding
+	if borderPad < 0 {
+		borderPad = 0
+	}
+	innerW := r.Width - 2 - 2*borderPad
 	if innerW < 1 {
 		innerW = 1
 	}
@@ -68,10 +72,11 @@ func (r Region) renderBoxed(content string) string {
 	if innerH < 0 {
 		innerH = 0
 	}
+	pad := strings.Repeat(" ", borderPad)
 
 	var b strings.Builder
 
-	// Top border: ┌──┬──┐ or ┌─────┐
+	// Top border: title centered inside ┌──┐, or plain ┌─────┐
 	topRule := strings.Repeat("─", innerW)
 	if r.Title != "" {
 		title := " " + r.Title + " "
@@ -89,22 +94,18 @@ func (r Region) renderBoxed(content string) string {
 		b.WriteString("┌" + topRule + "┐\n")
 	}
 
-	// Content lines.
+	// Content lines: │ pad content padspaces pad │
 	contentLines := strings.Split(content, "\n")
 	for i := 0; i < innerH; i++ {
 		if i < len(contentLines) {
 			line := contentLines[i]
-			if r.Padding > 0 {
-				pad := strings.Repeat(" ", r.Padding)
-				line = pad + line
-			}
 			padWidth := innerW - lipgloss.Width(line)
 			if padWidth < 0 {
 				padWidth = 0
 			}
-			b.WriteString("│ " + line + strings.Repeat(" ", padWidth) + " │\n")
+			b.WriteString("│" + pad + line + strings.Repeat(" ", padWidth) + pad + "│\n")
 		} else {
-			b.WriteString("│" + strings.Repeat(" ", innerW+2) + "│\n")
+			b.WriteString("│" + strings.Repeat(" ", innerW+2*borderPad) + "│\n")
 		}
 	}
 

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -41,7 +41,7 @@ const (
 	ActionDismissCancel
 )
 
-// Action is a behavioral intent — not a presentation object.
+// Action is a behavioral intent -- not a presentation object.
 type Action struct {
 	ID       ActionID
 	Category ActionCategory
@@ -86,7 +86,7 @@ var actionBindings = map[ActionID]actionBinding{
 	ActionSelect:            {"↑↓", "Select", NavigationCategory, PriorityHigh},
 	ActionInspect:           {"Enter", "Inspect", NavigationCategory, PriorityHigh},
 	ActionSwitchView:        {"Tab", "Views", NavigationCategory, PriorityMedium},
-	ActionConfigureRequest:  {"e", "Request", ConfigurationCategory, PriorityCritical},
+	ActionConfigureRequest:  {"e", "Configure", ConfigurationCategory, PriorityCritical},
 	ActionRun:               {"Ctrl+R", "Run", OperationCategory, PriorityCritical},
 	ActionCancel:            {"Ctrl+X", "Cancel", OperationCategory, PriorityCritical},
 	ActionNextField:         {"Tab", "Next Field", ConfigurationCategory, PriorityHigh},

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -40,6 +40,9 @@ var (
 	styleSectionLine = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorMuted))
 
+	styleHeading = lipgloss.NewStyle().
+			Bold(true)
+
 	styleDomainActive = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorAccent))
 

--- a/internal/tui/v091_audit_test.go
+++ b/internal/tui/v091_audit_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Suite 1 — Constitutional Audit
+// Suite 1  --  Constitutional Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Constitution_OrientationDelegates(t *testing.T) {
@@ -48,7 +48,7 @@ func TestV091Constitution_SurfacesAreNamedTypes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 2 — Behaviour Audit
+// Suite 2  --  Behaviour Audit
 // ---------------------------------------------------------------------------
 
 func keyMsgRune(r rune) tea.KeyMsg {
@@ -130,7 +130,7 @@ func TestV091Behaviour_RequestNoDeadKeys(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 3 — Visual Audit
+// Suite 3  --  Visual Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Visual_DomainHeadersUseCenteredRules(t *testing.T) {
@@ -159,20 +159,20 @@ func TestV091Visual_FooterHasHighlightedAction(t *testing.T) {
 	out := m.renderStatusline(m.ShellState(), 100)
 
 	if !strings.Contains(out, "[e]") {
-		t.Fatal("ribbon should show [e] Request")
+		t.Fatal("ribbon should show [e] Configure")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Suite 4 — Composition Audit
+// Suite 4  --  Composition Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Composition_ContextPanelAtWideWidths(t *testing.T) {
 	m := newTimelineRunningModel()
 	m.shell.Resize(160, 40)
 	out := m.View()
-	if !strings.Contains(out, "Selected Request") {
-		t.Fatal("wide terminal should show Selected Request context panel")
+	if !strings.Contains(out, "Selection") {
+		t.Fatal("wide terminal should show context panel")
 	}
 }
 
@@ -210,7 +210,7 @@ func TestV091Composition_ContextPanelAtAllSurfaces(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 5 — Information Architecture Audit
+// Suite 5  --  Information Architecture Audit
 // ---------------------------------------------------------------------------
 
 func TestV091IA_WorkspaceIdentityVisible(t *testing.T) {
@@ -246,13 +246,13 @@ func TestV091IA_ActiveDomainVisuallyDistinct(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 6 — Operator Walkthrough
+// Suite 6  --  Operator Walkthrough
 // ---------------------------------------------------------------------------
 
 func TestV091Walkthrough_RequestRunInspectQuit(t *testing.T) {
 	m := NewModel()
 
-	// 1. Start — should show OBSERVE identity
+	// 1. Start  --  should show OBSERVE identity
 	m.shell.Resize(100, 30)
 	if !strings.Contains(m.View(), "OBSERVE") {
 		t.Fatal("initial state should show OBSERVE")
@@ -329,7 +329,7 @@ func TestV091Walkthrough_RequestRunInspectQuit(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 7 — Navigation Audit
+// Suite 7  --  Navigation Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Navigation_UpDownInRequest(t *testing.T) {
@@ -345,7 +345,7 @@ func TestV091Navigation_UpDownInRequest(t *testing.T) {
 		t.Fatal("Up from URL should move to Method field")
 	}
 
-	// Up again at Method — should stay at Method (already at top)
+	// Up again at Method  --  should stay at Method (already at top)
 	updated, _ = m2.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyUp})
 	m3 := updated.(Model)
 	if m3.requestField != reqFieldMethod {
@@ -359,7 +359,7 @@ func TestV091Navigation_UpDownInRequest(t *testing.T) {
 		t.Fatal("Down from Method should move to URL field")
 	}
 
-	// Down at URL — should stay at URL (already at bottom)
+	// Down at URL  --  should stay at URL (already at bottom)
 	m5 := m4.(Model)
 	updated, _ = m5.handleRequestDomainKey(tea.KeyMsg{Type: tea.KeyDown})
 	if updated.(Model).requestField != reqFieldURL {
@@ -385,7 +385,7 @@ func TestV091Navigation_BlurAllBeforeDomainTransition(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 8 — Visual Rhythm Audit
+// Suite 8  --  Visual Rhythm Audit
 // ---------------------------------------------------------------------------
 
 func TestV091VisualRhythm_SectionLines(t *testing.T) {
@@ -444,7 +444,7 @@ func TestV091VisualRhythm_IdentityPrecedesFirstDomain(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 9 — Interaction Ownership Audit
+// Suite 9  --  Interaction Ownership Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Ownership_ArrowKeysNeverProduceTextInRequestDomain(t *testing.T) {
@@ -466,7 +466,7 @@ func TestV091Ownership_VimKeysInsertTextInURL(t *testing.T) {
 	if !strings.HasSuffix(m2.urlInput.Value(), "k") {
 		t.Fatal("'k' should insert 'k' into URL when URL is focused")
 	}
-	// Now press 'j' at end of URL — should insert 'j', not navigate
+	// Now press 'j' at end of URL  --  should insert 'j', not navigate
 	m2.urlInput.SetCursor(len(m2.urlInput.Value()))
 	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m3 := updated2.(Model)
@@ -587,7 +587,7 @@ func TestV091Ownership_AdvanceDomainGranularTab(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 10 — Visual Hierarchy Audit
+// Suite 10  --  Visual Hierarchy Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Visual_BadgeUsesAccentBackground(t *testing.T) {
@@ -614,21 +614,20 @@ func TestV091Visual_DomainHeaderUsesWeightNotBox(t *testing.T) {
 	if !strings.Contains(out, "━") {
 		t.Fatal("active domain header should use heavy weight ━")
 	}
-	// No left accent bar — that's v0.9.2 Regions
 	if strings.Contains(out, "▎") {
-		t.Fatal("v0.9.1 must not use left accent bar (▎) — that's v0.9.2")
+		t.Fatal("active domain header must not use left accent bar")
 	}
 }
 
-func TestV091Visual_ModeCellStatusCellSeparate(t *testing.T) {
+func TestV091Visual_BadgeStatusSeparate(t *testing.T) {
 	m := newRequestModel()
 	m.shell.Resize(100, 24)
 	out := m.renderStatusline(m.ShellState(), 100)
-	// Mode cell: should contain workspace badge
+	// Ribbon badge should contain workspace identity
 	if !strings.Contains(out, "REQUEST") {
-		t.Fatal("statusline mode cell should contain REQUEST")
+		t.Fatal("ribbon badge should contain REQUEST")
 	}
-	// Status cell: should contain operational state (Editing for Request dialog)
+	// Ribbon status should contain operational state (Editing for Request dialog)
 	if !strings.Contains(out, "Editing") {
 		t.Fatal("statusline should contain operational status (Editing)")
 	}
@@ -637,30 +636,30 @@ func TestV091Visual_ModeCellStatusCellSeparate(t *testing.T) {
 func TestV091Visual_ThreeLevelTypography(t *testing.T) {
 	m := newRequestModel()
 	out := m.View()
-	// Level 1: Badge "REQUEST" — must appear
+	// Level 1: Badge "REQUEST"  --  must appear
 	if !strings.Contains(out, "REQUEST") {
 		t.Fatal("Level 1 typography (badge) must be visible")
 	}
-	// Level 2: Domain header "Request" — must use ━/─ weight
+	// Level 2: Domain header "Request"  --  must use ━/─ weight
 	if !strings.Contains(out, "━") && !strings.Contains(out, "─") {
 		t.Fatal("Level 2 typography (domain header) must use heavy/light rules")
 	}
-	// Level 3: Section labels (like URL label) — must appear
+	// Level 3: Section labels (like URL label)  --  must appear
 	if !strings.Contains(out, "URL") {
 		t.Fatal("Level 3 typography (section label) must be visible")
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Suite 11 — Adaptive Layout Audit
+// Suite 11  --  Adaptive Layout Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Adaptive_WidePrimaryAndContext(t *testing.T) {
 	m := newTimelineRunningModel()
 	m.shell.Resize(160, 40)
 	out := m.View()
-	if !strings.Contains(out, "Selected Request") {
-		t.Fatal("wide terminal (≥140) must show context panel")
+	if !strings.Contains(out, "Selection") {
+		t.Fatal("wide terminal (>=140) must show context panel")
 	}
 	if !strings.Contains(out, "Timeline") {
 		t.Fatal("wide terminal must show primary content")
@@ -671,7 +670,7 @@ func TestV091Adaptive_MediumPrimaryOnly(t *testing.T) {
 	m := newTimelineRunningModel()
 	m.shell.Resize(120, 40)
 	out := m.View()
-	if strings.Contains(out, "Selected Request") {
+	if strings.Contains(out, "Selection") {
 		t.Fatal("medium terminal (<140) must NOT show context panel")
 	}
 	if len(out) == 0 {
@@ -704,7 +703,7 @@ func TestV091Adaptive_AllSurfacesAtAllLayouts(t *testing.T) {
 					m.shell.Resize(s.w, s.h)
 					out := m.View()
 					if len(out) == 0 {
-						t.Fatal("empty output — surface must render")
+						t.Fatal("empty output  --  surface must render")
 					}
 					// Visual width invariant: every line must match the layout width,
 					// which may exceed the requested terminal width (shell imposes a minimum of 72)
@@ -721,7 +720,7 @@ func TestV091Adaptive_AllSurfacesAtAllLayouts(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 12 — Boundary Traversal Audit
+// Suite 12  --  Boundary Traversal Audit
 // ---------------------------------------------------------------------------
 
 func TestV091Boundary_ReverseTabFromBodyToHeaders(t *testing.T) {
@@ -800,7 +799,7 @@ func TestV091Boundary_ArrowDownAtUrlToPayload(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Suite 13 — Responsive Statusline Invariants
+// Suite 13  --  Responsive Statusline Invariants
 // ---------------------------------------------------------------------------
 
 type responsiveTestCase struct {

--- a/internal/tui/v092_audit_test.go
+++ b/internal/tui/v092_audit_test.go
@@ -998,6 +998,80 @@ func TestV092Interaction_HJKLConsistency(t *testing.T) {
 	}
 }
 
+// Invariant: Empty-state navigation is safe (no panics, no state change).
+
+func TestV092Interaction_EmptyStateNavigationSafety(t *testing.T) {
+	// Navigation keys in the idle state (no results) must not panic and
+	// must not change the selection index or mode.
+	m := NewModel()
+	keys := []tea.KeyMsg{
+		{Type: tea.KeyUp},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyPgUp},
+		{Type: tea.KeyPgDown},
+	}
+	for _, k := range keys {
+		t.Run(k.Type.String(), func(t *testing.T) {
+			updated, _ := m.Update(k)
+			m2 := updated.(Model)
+			if m2.selected != 0 {
+				t.Fatalf("empty-state navigation with %s changed selected to %d", k.Type.String(), m2.selected)
+			}
+			if m2.workspace.mode != modeObserve {
+				t.Fatalf("empty-state navigation with %s changed mode", k.Type.String())
+			}
+		})
+	}
+}
+
+// Invariant: Ctrl+R dispatches from every request domain.
+
+func TestV092Interaction_CtrlRFromEveryDomain(t *testing.T) {
+	// Ctrl+R must start a run from Request, Payload, and Exec domains.
+	domains := []struct {
+		name  string
+		setup func(m *Model)
+	}{
+		{"Request", func(m *Model) { m.activeDomain = DomainRequest }},
+		{"Payload", func(m *Model) { m.activeDomain = DomainPayload }},
+		{"Exec", func(m *Model) { m.activeDomain = DomainExec }},
+	}
+	for _, d := range domains {
+		t.Run(d.name, func(t *testing.T) {
+			m := NewModel()
+			m.workspace.dialog = dialogRequest
+			d.setup(&m)
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+			m2 := updated.(Model)
+			if !m2.running {
+				t.Fatalf("ctrl+R from %s domain did not start a run", d.name)
+			}
+			if cmd == nil {
+				t.Fatalf("ctrl+R from %s domain produced no command", d.name)
+			}
+		})
+	}
+}
+
+// Invariant: Ctrl+X from within the Request dialog cancels the run.
+
+func TestV092Interaction_CtrlXFromDialog(t *testing.T) {
+	m := NewModel()
+	m.workspace.dialog = dialogRequest
+	m.running = true
+	m.cancel = func() {}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlX})
+	m2 := updated.(Model)
+	if m2.running {
+		t.Fatal("ctrl+X from Request dialog should cancel the run")
+	}
+	if m2.status != "CANCELLED" {
+		t.Fatalf("ctrl+X from Request dialog should set status to CANCELLED, got %q", m2.status)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Section: Layout
 //
@@ -1260,3 +1334,27 @@ func TestV092IA_EmptyStatesGuide(t *testing.T) {
 //   - Semantic constants are used in place of magic literals
 //   - No deprecated or superseded conventions remain
 // ---------------------------------------------------------------------------
+
+func TestV092Engineering_SentinelConstantUsed(t *testing.T) {
+	// Verify the sentinelEmpty constant is used instead of hardcoded
+	// em dash strings for the empty payload sentinel.
+	m := NewModel()
+	if m.payloadSummary() != sentinelEmpty {
+		t.Fatal("payloadSummary should return sentinelEmpty for empty payload")
+	}
+}
+
+func TestV092Engineering_NoStaleCCReferences(t *testing.T) {
+	// Verify the Configuration function uses "Concurrency" not "CC".
+	cfg := NewModel().Configuration()
+	for _, c := range cfg {
+		if c.Identity == "CC" {
+			t.Fatal("Configuration should use Concurrency, not CC")
+		}
+	}
+}
+
+func TestV092Engineering_NeedlessBlank(t *testing.T) {
+	// Placeholder for future engineering consistency checks.
+	// This section grows as the audit infrastructure evolves.
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -11,6 +11,15 @@ import (
 	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
+const sentinelEmpty = "—"
+
+const (
+	gapSection      = "\n\n"
+	indentField     = "  "
+	indentNested    = "    "
+	inlineSeparator = " · "
+)
+
 func (m Model) Actions() []Action {
 	switch {
 	case m.workspace.dialog == dialogConfirmQuit:
@@ -75,7 +84,7 @@ func (m Model) Configuration() []configItem {
 		{"URL", m.urlInput.Value(), m.urlInput.Value() != ""},
 		{"Concurrency", strings.TrimSpace(m.concurrencyInput.Value()), true},
 	}
-	if ps != "—" {
+	if ps != sentinelEmpty {
 		items = append(items, configItem{"Payload", ps, true})
 	}
 	return items
@@ -111,7 +120,8 @@ func (m Model) View() string {
 	ws := layout.Workspace
 	ws.Border = BorderFull
 	ws.Title = orientation
-	inner := Region{Type: WorkspaceRegion, Width: ws.Width - 4, Height: ws.Height - 2}
+	ws.Padding = 1
+	inner := Region{Type: WorkspaceRegion, Width: ws.Width - 2 - 2*ws.Padding, Height: ws.Height - 2}
 	sb.WriteString(ws.RenderBordered(m.renderWorkspaceContent(inner, w)))
 	sb.WriteString("\n")
 
@@ -163,34 +173,34 @@ func (m Model) renderObserveContext(region Region) string {
 	reqURL := m.effectiveURL(result)
 
 	var b strings.Builder
-	b.WriteString(accentOrMuted("Selected Request", true))
-	b.WriteString("\n\n")
-	b.WriteString(fmt.Sprintf("  %s %s\n", method, truncateURL(reqURL, region.Width-12)))
-	b.WriteString(fmt.Sprintf("  %s\n", renderStatusBadge(result)))
-	b.WriteString(fmt.Sprintf("  Latency: %s\n", formatDuration(result.Latency)))
+	b.WriteString(accentOrMuted("Selection", true))
+	b.WriteString(gapSection)
+	b.WriteString(fmt.Sprintf(indentField+"%s %s\n", method, truncateURL(reqURL, region.Width-12)))
+	b.WriteString(fmt.Sprintf(indentField+"%s\n", renderStatusBadge(result)))
+	b.WriteString(fmt.Sprintf(indentField+"Latency: %s\n", formatDuration(result.Latency)))
 	return regionStyle(region).Render(b.String())
 }
 
 func (m Model) renderInspectContext(region Region) string {
 	var b strings.Builder
-	b.WriteString(accentOrMuted("Metrics", false))
-	b.WriteString("\n\n")
-	b.WriteString(fmt.Sprintf("  Duration: %s\n", formatDuration(m.elapsed)))
-	b.WriteString(fmt.Sprintf("  Requests: %d\n", len(m.results)))
+	b.WriteString(accentOrMuted("Run Metrics", false))
+	b.WriteString(gapSection)
+	b.WriteString(fmt.Sprintf(indentField+"Duration: %s\n", formatDuration(m.elapsed)))
+	b.WriteString(fmt.Sprintf(indentField+"Requests: %d\n", len(m.results)))
 	if metrics := m.metricsString(); metrics != "" {
-		b.WriteString(fmt.Sprintf("  %s\n", metrics))
+		b.WriteString(fmt.Sprintf(indentField+"%s\n", metrics))
 	}
 	return regionStyle(region).Render(b.String())
 }
 
 func (m Model) renderRequestContext(region Region) string {
 	var b strings.Builder
-	b.WriteString(accentOrMuted("Preview", false))
-	b.WriteString("\n\n")
-	b.WriteString(fmt.Sprintf("  Method: %s\n", runconfig.AllowedMethods()[m.methodIndex]))
-	b.WriteString(fmt.Sprintf("  URL: %s\n", truncateURL(m.urlInput.Value(), region.Width-8)))
-	b.WriteString(fmt.Sprintf("  CC: %d\n", m.concurrency()))
-	b.WriteString(fmt.Sprintf("  Payload: %s\n", m.payloadSummary()))
+	b.WriteString(accentOrMuted("Configuration", false))
+	b.WriteString(gapSection)
+	b.WriteString(fmt.Sprintf(indentField+"Method: %s\n", runconfig.AllowedMethods()[m.methodIndex]))
+	b.WriteString(fmt.Sprintf(indentField+"URL: %s\n", truncateURL(m.urlInput.Value(), region.Width-8)))
+	b.WriteString(fmt.Sprintf(indentField+"C: %d\n", m.concurrency()))
+	b.WriteString(fmt.Sprintf(indentField+"Payload: %s\n", m.payloadSummary()))
 	return regionStyle(region).Render(b.String())
 }
 
@@ -216,7 +226,7 @@ func (m Model) payloadSummary() string {
 	hasBody := m.bodyInput.Value() != ""
 	switch {
 	case h == 0 && !hasBody:
-		return "—"
+		return sentinelEmpty
 	case h > 0 && hasBody:
 		return fmt.Sprintf("%dH+B", h)
 	case h > 0:
@@ -264,19 +274,19 @@ func (m Model) renderReady(region Region) string {
 	url := m.urlInput.Value()
 	cc := m.concurrency()
 
-	payloadLabel := "Payload " + m.payloadSummary()
-
-	identity := renderWorkspaceBadge("OBSERVE")
-
-	content := fmt.Sprintf("%s    %s\n\nC %d\n\n%s",
-		method, url, cc, payloadLabel)
+	payloadLabel := m.payloadSummary()
 
 	var b strings.Builder
-	b.WriteString(identity)
-	b.WriteString("\n\n")
-	b.WriteString(content)
-	b.WriteString("\n")
-	b.WriteString(styleMuted.Render("Ready — configure a request to begin"))
+	b.WriteString(styleMuted.Render("Ready"))
+	b.WriteString(gapSection)
+	b.WriteString(accentOrMuted("Current Request", true))
+	b.WriteString(gapSection)
+	b.WriteString("Method\n" + method + gapSection)
+	b.WriteString("URL\n" + url + gapSection)
+	b.WriteString(fmt.Sprintf("Concurrency\n%d"+gapSection, cc))
+	b.WriteString("Payload\n" + payloadLabel + gapSection)
+	b.WriteString("Status\n")
+	b.WriteString(styleMuted.Render("Ready to execute"))
 
 	return regionStyle(region).Render(b.String())
 }
@@ -346,7 +356,7 @@ func (m Model) renderRequestDomain(width int) string {
 		methodLabel = styleMuted.Render("Method")
 	}
 
-	b.WriteString(fmt.Sprintf("  %s\n    %s\n", methodLabel, methodLine))
+	b.WriteString(fmt.Sprintf(indentField+"%s\n"+indentNested+"%s\n", methodLabel, methodLine))
 
 	urlLabel := "URL"
 	if m.activeDomain == DomainRequest && m.requestField == reqFieldURL {
@@ -354,7 +364,7 @@ func (m Model) renderRequestDomain(width int) string {
 	} else {
 		urlLabel = styleMuted.Render("URL")
 	}
-	b.WriteString(fmt.Sprintf("  %s\n    %s\n", urlLabel, m.urlInput.View()))
+	b.WriteString(fmt.Sprintf(indentField+"%s\n"+indentNested+"%s\n", urlLabel, m.urlInput.View()))
 
 	return b.String()
 }
@@ -366,18 +376,18 @@ func (m Model) renderPayloadDomain(width int) string {
 	b.WriteString("\n")
 
 	headersActive := m.activeDomain == DomainPayload && m.selectedHead != bodyFocus
-	b.WriteString(accentOrMuted("  HEADERS  ctrl+n add  ctrl+d remove", headersActive))
+	b.WriteString(accentOrMuted(indentField+"HEADERS  ctrl+n add  ctrl+d remove", headersActive))
 	b.WriteString("\n")
 
 	if len(m.headers) == 0 {
-		b.WriteString(styleMuted.Render("    No headers configured."))
+		b.WriteString(styleMuted.Render(indentNested + "No headers configured."))
 	} else {
 		for i, header := range m.headers {
 			key := header.Key.View()
 			value := header.Value.View()
 			sel := i == m.selectedHead
 			cursor := rowCursor(sel)
-			line := fmt.Sprintf("  %s %s: %s", cursor, key, value)
+			line := fmt.Sprintf(indentField+"%s %s: %s", cursor, key, value)
 			b.WriteString(rowStyle(sel).Render(line))
 			b.WriteString("\n")
 		}
@@ -385,13 +395,13 @@ func (m Model) renderPayloadDomain(width int) string {
 
 	bodyActive := m.activeDomain == DomainPayload && m.selectedHead == bodyFocus
 	bodyLen := len(m.bodyInput.Value())
-	bodyLabel := "  BODY"
+	bodyLabel := indentField + "BODY"
 	if bodyLen > 0 {
-		bodyLabel = fmt.Sprintf("  BODY (%d KB / %d KB)", bodyLen/1024, maxTUIBodyBytes/1024)
+		bodyLabel = fmt.Sprintf(indentField+"BODY (%d KB / %d KB)", bodyLen/1024, maxTUIBodyBytes/1024)
 	}
 	b.WriteString(accentOrMuted(bodyLabel, bodyActive))
 	b.WriteString("\n")
-	b.WriteString("  " + m.bodyInput.View())
+	b.WriteString(indentField + m.bodyInput.View())
 	b.WriteString("\n")
 
 	return b.String()
@@ -405,12 +415,12 @@ func (m Model) renderExecDomain(width int) string {
 
 	ccText := strings.TrimSpace(m.concurrencyInput.View())
 	active := m.activeDomain == DomainExec
-	ccLabel := accentOrMuted("  Concurrency", active)
+	ccLabel := accentOrMuted(indentField+"Concurrency", active)
 	if active {
-		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccText, runconfig.MaxConcurrency))
+		b.WriteString(fmt.Sprintf("%s: %s  (1-%d)\n", ccLabel, ccText, runconfig.MaxConcurrency))
 	} else {
 		ccVal := styleBase.Foreground(lipgloss.Color(colorText)).Render(ccText)
-		b.WriteString(fmt.Sprintf("%s: %s  (1–%d)\n", ccLabel, ccVal, runconfig.MaxConcurrency))
+		b.WriteString(fmt.Sprintf("%s: %s  (1-%d)\n", ccLabel, ccVal, runconfig.MaxConcurrency))
 	}
 
 	return b.String()
@@ -513,8 +523,8 @@ func buildActionStrip(actions []Action, level Density) string {
 		return ""
 	}
 
-	groupGap := "    "
-	withinSep := " · "
+	groupGap := indentNested
+	withinSep := inlineSeparator
 	if level >= DensityRelaxed {
 		groupGap = " "
 	}
@@ -625,7 +635,7 @@ func (m Model) renderResultList(region Region, identity string, emptyRunning str
 	var b strings.Builder
 
 	b.WriteString(identityCell(identity))
-	b.WriteString("\n\n")
+	b.WriteString(gapSection)
 
 	remaining := region.Height - 2
 	if metrics := m.metricsString(); metrics != "" {
@@ -668,7 +678,7 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	latency := formatDuration(result.Latency)
 	method := m.effectiveMethod(result)
 
-	barWidth := max(6, width-38)
+	barWidth := max(6, width-34)
 	filled := 0
 	if maxLatency > 0 {
 		filled = int(float64(result.Latency) / float64(maxLatency) * float64(barWidth))
@@ -680,8 +690,8 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	barColor := statusColor(result.Status)
 	bar := renderLatencyBar(filled, barWidth, barColor)
 
-	line := fmt.Sprintf("%s %3d %-4s %-12s %s %s",
-		rowCursor(selected), index+1, method, status, bar, latency)
+	line := fmt.Sprintf("%s %-4s %-12s %s %s",
+		rowCursor(selected), method, status, bar, latency)
 
 	if isErrorResult(result) {
 		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
@@ -695,8 +705,8 @@ func (m Model) renderLogs(region Region) string {
 			status := resultStatus(result)
 			method := m.effectiveMethod(result)
 			reqURL := m.effectiveURL(result)
-			line := fmt.Sprintf("%s %3d %-4s %-10s %-8s %s",
-				rowCursor(selected), index+1, method, status, formatDuration(result.Latency), truncate(reqURL, width-33))
+			line := fmt.Sprintf("%s %-4s %-10s %-8s %s",
+				rowCursor(selected), method, status, formatDuration(result.Latency), truncate(reqURL, width-29))
 			if isErrorResult(result) {
 				return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
 			}
@@ -717,20 +727,19 @@ func (m Model) renderInspect(region Region) string {
 		return styleSectionLine.Render("── " + label + " ──")
 	}
 
-	identity := identityCell(fmt.Sprintf("Inspector - Result #%d", m.selected+1))
+	identity := identityCell(fmt.Sprintf("Result %d", m.selected+1))
 
 	lines := []string{
 		identity,
-		"",
-		fmt.Sprintf("  %s %s", method, truncate(reqURL, region.Width-12)),
-		"",
+		gapSection,
+		fmt.Sprintf("%s %s", method, truncate(reqURL, region.Width-4)),
 		renderStatusBadge(result),
 		fmt.Sprintf("Latency: %s", formatDuration(result.Latency)),
 	}
 	if result.Error != "" {
 		lines = append(lines, styleError.Render("Error: "+result.Error))
 	}
-	lines = append(lines, "", sectionLine("HEADERS"))
+	lines = append(lines, gapSection, sectionLine("HEADERS"))
 
 	if len(result.ResponseHeaders) == 0 {
 		lines = append(lines, styleMuted.Render("No headers captured."))
@@ -745,7 +754,7 @@ func (m Model) renderInspect(region Region) string {
 		}
 	}
 
-	lines = append(lines, "", sectionLine("BODY"))
+	lines = append(lines, gapSection, sectionLine("BODY"))
 	body := result.ResponseBody
 	if body == "" {
 		body = styleMuted.Render("No body captured.")

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -1,11 +1,13 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/divijg19/Pulse/internal/model"
+	"github.com/divijg19/Pulse/internal/runconfig"
 )
 
 func contains(t *testing.T, s, substr string) bool {
@@ -51,20 +53,26 @@ func TestRenderReady(t *testing.T) {
 	m := NewModel()
 	m.shell.Resize(100, 30)
 	out := m.renderReady(Region{Width: 100, Height: 26})
-	if !contains(t, out, "OBSERVE") {
-		t.Fatal("Ready should show identity")
+	if !contains(t, out, "Ready") {
+		t.Fatal("Ready should show status heading")
+	}
+	if !contains(t, out, "Current Request") {
+		t.Fatal("Ready should show current request heading")
 	}
 	if !contains(t, out, "httpbin") {
 		t.Fatal("Ready should show URL")
 	}
-	if !contains(t, out, "C 10") {
+	if !contains(t, out, fmt.Sprintf("%d", runconfig.DefaultConcurrency)) {
 		t.Fatal("Ready should show concurrency")
 	}
 	if !contains(t, out, "Payload") {
-		t.Fatal("Ready should show payload state")
+		t.Fatal("Ready should show payload field")
 	}
-	if !contains(t, out, "—") {
-		t.Fatal("Ready should show payload as empty (—)")
+	if !contains(t, out, sentinelEmpty) {
+		t.Fatal("Ready should show payload as empty")
+	}
+	if !contains(t, out, "Ready to execute") {
+		t.Fatal("Ready should show readiness status")
 	}
 }
 
@@ -73,8 +81,8 @@ func TestRenderReady_HidesAfterFirstRun(t *testing.T) {
 	m.shell.Resize(100, 30)
 
 	out := m.View()
-	if !contains(t, out, "OBSERVE") {
-		t.Fatal("first launch should show Ready surface")
+	if !contains(t, out, "Ready to execute") {
+		t.Fatal("first launch should show Ready surface with readiness status")
 	}
 
 	m.results = []model.Result{{Status: 200, Latency: 100 * time.Millisecond}}
@@ -213,8 +221,8 @@ func TestRenderStatusline_Ready(t *testing.T) {
 	m := NewModel()
 	m.shell.Resize(100, 24)
 	out := m.renderStatusline(m.ShellState(), 100)
-	if !contains(t, out, "[e] Request") {
-		t.Fatal("ready ribbon should show [e] Request")
+	if !contains(t, out, "[e] Configure") {
+		t.Fatal("ready ribbon should show [e] Configure")
 	}
 	if contains(t, out, "[↑↓]") {
 		t.Fatal("ready ribbon should not advertise [↑↓] (inert)")
@@ -437,10 +445,7 @@ func TestRenderInspect_Identity(t *testing.T) {
 	}
 
 	out := m.renderInspect(Region{Width: 40, Height: 20})
-	if !contains(t, out, "Inspector") {
-		t.Fatal("inspector should show identity header")
-	}
-	if !contains(t, out, "Result #1") {
+	if !contains(t, out, "Result 1") {
 		t.Fatal("inspector should show result number")
 	}
 }
@@ -853,7 +858,7 @@ func TestRenderRequest_ExecutionIdentity(t *testing.T) {
 	if !contains(t, out, "7") {
 		t.Fatal("execution should show current concurrency value")
 	}
-	if !contains(t, out, "1–100") {
+	if !contains(t, out, "1-100") {
 		t.Fatal("execution should show range affordance")
 	}
 }
@@ -891,7 +896,7 @@ func TestRenderRequest_ExecDomain_Focused(t *testing.T) {
 	if !contains(t, out, "REQUEST") {
 		t.Fatal("should show identity")
 	}
-	if !contains(t, out, "1–100") {
+	if !contains(t, out, "1-100") {
 		t.Fatal("should show range")
 	}
 	if !m.concurrencyInput.Focused() {
@@ -980,7 +985,7 @@ func TestRenderCurrentSurface_DispatchesToSurface(t *testing.T) {
 
 	// Ready state
 	out := m.resolveSurface().Render(region)
-	if !contains(t, out, "OBSERVE") {
+	if !contains(t, out, "Ready") {
 		t.Fatal("renderCurrentSurface should render Ready when idle")
 	}
 }
@@ -997,10 +1002,7 @@ func TestRenderWorkspace_InspectorDrillDown(t *testing.T) {
 	m.selected = 0
 
 	out := m.View()
-	if !contains(t, out, "Inspector") {
-		t.Fatal("workspace with inspector should show Inspector header")
-	}
-	if !contains(t, out, "Result #1") {
+	if !contains(t, out, "Result 1") {
 		t.Fatal("workspace with inspector should show result number")
 	}
 	if !contains(t, out, "200") {
@@ -1195,9 +1197,9 @@ func TestRenderStatusline_WithinGroupSeparator(t *testing.T) {
 	m := NewModel()
 	m.shell.Resize(100, 24)
 	out := m.renderStatusline(m.ShellState(), 100)
-	// Ready state: [e] Request in Configuration group.
-	if !contains(t, out, "[e] Request") {
-		t.Fatal("ready state should show [e] Request")
+	// Ready state: [e] Configure in Configuration group.
+	if !contains(t, out, "[e] Configure") {
+		t.Fatal("ready state should show [e] Configure")
 	}
 }
 
@@ -1207,7 +1209,7 @@ func TestRenderStatusline_BetweenGroupSeparator(t *testing.T) {
 	out := m.renderStatusline(m.ShellState(), 100)
 	// Ready state: Configuration group followed by Operation group.
 	// Must have 4-space gap between groups.
-	if !contains(t, out, "Request    [Ctrl+R]") {
+	if !contains(t, out, "Configure    [Ctrl+R]") {
 		t.Fatal("different category groups must be separated by wider gap (4 spaces)")
 	}
 }
@@ -1502,7 +1504,7 @@ func TestConfiguration_MethodAndURL(t *testing.T) {
 	m.shell.Resize(100, 24)
 	cfg := m.Configuration()
 	if len(cfg) < 3 {
-		t.Fatal("Configuration should have at least 3 items (Method, URL, CC)")
+		t.Fatal("Configuration should have at least 3 items (Method, URL, Concurrency)")
 	}
 	if cfg[0].Identity != "Method" || cfg[0].Value == "" {
 		t.Fatal("Configuration[0] should be Method with a value")


### PR DESCRIPTION
Four sequenced tracks completed for v0.9.3:

Track 0: Repository Convergence
  * Sentinel constant: sentinelEmpty replaces em dash magic strings in payloadSummary() and Configuration()
  * Terminology: CC -> Concurrency, Preview -> Configuration, Metrics -> Run Metrics, Selected Request -> Selection, Inspector - Result #N -> Result N
  * Em/en dash -> ASCII hyphen in test comments and exec range (1-100 -> 1-100)
  * Architectural invariant tests: workspace single source, surface resolvability, determinism, render does not mutate

Track 1: Interaction Language Completion
  * Empty-state navigation: up/down/enter/pgup/pgdn in idle state are no-ops (no panic, no selected change, no mode change)
  * Ctrl+R dispatches from all three request domains (Request, Payload, Exec)
  * Ctrl+X cancels a running request from within the Request dialog
  * Engineering tests for sentinel constant usage and stale reference detection

Track 2: Workspace Cohesion
  * Ready workspace: redesigned as calm overview -- no badge, muted heading, structured vertical fields (Method, URL, Concurrency, Payload, Status)
  * Context panel headings renamed: Preview -> Configuration, Metrics -> Run Metrics, Selected Request -> Selection
  * Footer label: "Request" -> "Configure" (action binding and all tests)
  * Timeline/Logs rows: index column removed, bar width adjusted accordingly
  * Inspect: heading simplified to "Result N", section gaps use gapSection

Track 3: Visual Language
  * Region.Padding: ws.Padding = 1; renderBoxed computes inner side padding from r.Padding instead of hardcoded 1; renders |pad content pad|
  * Spacing constants: gapSection, indentField, indentNested, inlineSeparator replace magic literals across all surfaces
  * Ribbon: groupGap defaults to indentNested, withinSep defaults to inlineSeparator
  * Typography: styleHeading added (bold, uncolored) for future use

Verification:
  go fmt ./...: clean
  go vet ./...: clean
  go build ./...: clean
  go test -count=1 ./...: all 9 packages pass
  go test -race ./internal/tui/: clean (1.82s)
  Architecture ownership matrix: verified clean (Shell owns separators/shortcuts,
  Workspace owns mode/dialog/view, Region owns geometry)
  Visual audit: all surfaces render without overflow at 72x10 through 220x40