### PR TITLE
v0.9.4: Workspace Integrity

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,6 +26,8 @@ const (
 
 	reqFieldMethod = 0
 	reqFieldURL    = 1
+
+	defaultURL = "https://httpbin.org/delay/1"
 )
 
 type mode int
@@ -92,8 +94,8 @@ type startupMsg struct{}
 
 func NewModel() Model {
 	url := textinput.New()
-	url.Placeholder = "https://httpbin.org/delay/1"
-	url.SetValue("https://httpbin.org/delay/1")
+	url.Placeholder = defaultURL
+	url.SetValue(defaultURL)
 	url.Prompt = ""
 	url.CharLimit = 2048
 
@@ -129,8 +131,8 @@ func (m Model) Init() tea.Cmd {
 
 func (m *Model) setBodyWidths(totalWidth int) {
 	innerWidth := totalWidth - 4
-	leftWidth := max(28, innerWidth/2-2)
-	rightWidth := max(28, innerWidth-leftWidth-3)
+	leftWidth := max(minPanelWidth, innerWidth/defaultBodySplitDiv-2)
+	rightWidth := max(minPanelWidth, innerWidth-leftWidth-3)
 	m.bodyInput.SetWidth(max(10, rightWidth-6))
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -33,11 +33,11 @@ func TestMethodSelection(t *testing.T) {
 func TestConcurrencyClamping(t *testing.T) {
 	m := NewModel()
 	m.setConcurrency(500)
-	if got := m.concurrency(); got != 100 {
+	if got := m.concurrency(); got != runconfig.MaxConcurrency {
 		t.Fatalf("concurrency high clamp = %d", got)
 	}
 	m.setConcurrency(-10)
-	if got := m.concurrency(); got != 1 {
+	if got := m.concurrency(); got != runconfig.MinConcurrency {
 		t.Fatalf("concurrency low clamp = %d", got)
 	}
 }

--- a/internal/tui/region.go
+++ b/internal/tui/region.go
@@ -76,17 +76,22 @@ func (r Region) renderBoxed(content string) string {
 
 	var b strings.Builder
 
-	// Top border: title centered inside ┌──┐, or plain ┌─────┐
-	topRule := strings.Repeat("─", innerW)
+	// The border dashes span the full width between walls, including
+	// any side padding.
+	borderDashWidth := innerW + 2*borderPad
+	if borderDashWidth < 0 {
+		borderDashWidth = 0
+	}
+	topRule := strings.Repeat("─", borderDashWidth)
 	if r.Title != "" {
 		title := " " + r.Title + " "
 		titleLen := lipgloss.Width(title)
-		if titleLen > innerW {
-			title = title[:innerW]
-			titleLen = innerW
+		if titleLen > borderDashWidth {
+			title = title[:borderDashWidth]
+			titleLen = borderDashWidth
 		}
-		leftCount := (innerW - titleLen) / 2
-		rightCount := innerW - titleLen - leftCount
+		leftCount := (borderDashWidth - titleLen) / 2
+		rightCount := borderDashWidth - titleLen - leftCount
 		leftRule := strings.Repeat("─", leftCount)
 		rightRule := strings.Repeat("─", rightCount)
 		b.WriteString("┌" + leftRule + title + rightRule + "┐\n")
@@ -109,8 +114,8 @@ func (r Region) renderBoxed(content string) string {
 		}
 	}
 
-	// Bottom border: └─────┘
-	b.WriteString("└" + strings.Repeat("─", innerW) + "┘\n")
+	// Bottom border: └─────┘ (same width as top border)
+	b.WriteString("└" + strings.Repeat("─", borderDashWidth) + "┘\n")
 
 	return r.styleBase().Render(strings.TrimSuffix(b.String(), "\n"))
 }

--- a/internal/tui/region_test.go
+++ b/internal/tui/region_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestRegionBoxed_RawWidthsMatch(t *testing.T) {
+	// The raw (pre-lipgloss) border and content lines must have identical
+	// character width. The top corner ┐ and bottom corner ┘ must appear at
+	// the same column as the right wall │ of content lines.
+	widths := []int{20, 40, 72}
+	paddings := []int{0, 1, 2}
+
+	for _, w := range widths {
+		for _, p := range paddings {
+			name := fmt.Sprintf("width=%d padding=%d", w, p)
+			t.Run(name, func(t *testing.T) {
+				r := Region{
+					Width:   w,
+					Height:  5,
+					Border:  BorderFull,
+					Padding: p,
+				}
+
+				rendered := r.renderBoxed("content")
+				lines := strings.Split(rendered, "\n")
+
+				if len(lines) < 3 {
+					t.Fatal("expected >=3 lines")
+				}
+
+				topLine := lines[0]
+				contentLine := lines[1]
+				bottomLine := lines[len(lines)-1]
+
+				// Check corners are at the end of their lines.
+				topRunes := []rune(topLine)
+				contentRunes := []rune(contentLine)
+				bottomRunes := []rune(bottomLine)
+
+				if string(topRunes[len(topRunes)-1]) != "┐" {
+					t.Errorf("top border last char = %q at rune len %d, want ┐",
+						string(topRunes[len(topRunes)-1]), len(topRunes))
+				}
+				if string(contentRunes[len(contentRunes)-1]) != "│" {
+					t.Errorf("content line last char = %q at rune len %d, want │",
+						string(contentRunes[len(contentRunes)-1]), len(contentRunes))
+				}
+				if string(bottomRunes[len(bottomRunes)-1]) != "┘" {
+					t.Errorf("bottom border last char = %q at rune len %d, want ┘",
+						string(bottomRunes[len(bottomRunes)-1]), len(bottomRunes))
+				}
+
+				// All three must have same rune count.
+				if len(topRunes) != len(contentRunes) || len(contentRunes) != len(bottomRunes) {
+					t.Errorf("raw rune lengths differ: top=%d content=%d bottom=%d (padding=%d)",
+						len(topRunes), len(contentRunes), len(bottomRunes), p)
+				}
+
+				// Also verify consistent lipgloss width.
+				tw := lipgloss.Width(topLine)
+				cw := lipgloss.Width(contentLine)
+				bw := lipgloss.Width(bottomLine)
+				if tw != cw || cw != bw {
+					t.Errorf("lipgloss widths differ: top=%d content=%d bottom=%d",
+						tw, cw, bw)
+				}
+			})
+		}
+	}
+}
+
+func TestRegionBoxed_TitledCorners(t *testing.T) {
+	r := Region{
+		Width:   40,
+		Height:  5,
+		Border:  BorderFull,
+		Padding: 1,
+		Title:   "OBSERVE",
+	}
+
+	rendered := r.renderBoxed("content")
+	lines := strings.Split(rendered, "\n")
+
+	topLine := lines[0]
+	contentLine := lines[1]
+	bottomLine := lines[len(lines)-1]
+
+	topRunes := []rune(topLine)
+	contentRunes := []rune(contentLine)
+	bottomRunes := []rune(bottomLine)
+
+	if string(topRunes[len(topRunes)-1]) != "┐" {
+		t.Errorf("titled top corner = %q, want ┐", string(topRunes[len(topRunes)-1]))
+	}
+	if string(contentRunes[len(contentRunes)-1]) != "│" {
+		t.Errorf("titled content wall = %q, want │", string(contentRunes[len(contentRunes)-1]))
+	}
+	if string(bottomRunes[len(bottomRunes)-1]) != "┘" {
+		t.Errorf("titled bottom corner = %q, want ┘", string(bottomRunes[len(bottomRunes)-1]))
+	}
+
+	if len(topRunes) != len(contentRunes) || len(contentRunes) != len(bottomRunes) {
+		t.Errorf("titled rune lengths differ: top=%d content=%d bottom=%d",
+			len(topRunes), len(contentRunes), len(bottomRunes))
+	}
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -15,8 +15,8 @@ const (
 
 var (
 	styleBase      = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
-	styleTopBar    = styleBase.Copy().Bold(true)
-	styleRibbon    = styleBase.Copy().Background(lipgloss.Color(colorDark))
+	styleTopBar    = styleBase.Bold(true)
+	styleRibbon    = styleBase.Background(lipgloss.Color(colorDark))
 	styleSeparator = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	styleMuted     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
 	styleAccent    = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent))
@@ -40,9 +40,6 @@ var (
 	styleSectionLine = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorMuted))
 
-	styleHeading = lipgloss.NewStyle().
-			Bold(true)
-
 	styleDomainActive = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorAccent))
 
@@ -51,7 +48,7 @@ var (
 )
 
 func regionStyle(region Region) lipgloss.Style {
-	return styleBase.Copy().Width(region.Width).Height(region.Height)
+	return styleBase.Width(region.Width).Height(region.Height)
 }
 
 func statusColor(status int) string {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -20,6 +20,17 @@ const (
 	inlineSeparator = " · "
 )
 
+const (
+	timelineFixedWidth  = 34
+	logsFixedWidth      = 29
+	contextRowWidth     = 12
+	contextURLWidth     = 8
+	minPanelWidth       = 28
+	defaultBodySplitDiv = 2
+	topBarURLWidth      = 40
+	topBarMinLeft       = 12
+)
+
 func (m Model) Actions() []Action {
 	switch {
 	case m.workspace.dialog == dialogConfirmQuit:
@@ -175,7 +186,7 @@ func (m Model) renderObserveContext(region Region) string {
 	var b strings.Builder
 	b.WriteString(accentOrMuted("Selection", true))
 	b.WriteString(gapSection)
-	b.WriteString(fmt.Sprintf(indentField+"%s %s\n", method, truncateURL(reqURL, region.Width-12)))
+	b.WriteString(fmt.Sprintf(indentField+"%s %s\n", method, truncateURL(reqURL, region.Width-contextRowWidth)))
 	b.WriteString(fmt.Sprintf(indentField+"%s\n", renderStatusBadge(result)))
 	b.WriteString(fmt.Sprintf(indentField+"Latency: %s\n", formatDuration(result.Latency)))
 	return regionStyle(region).Render(b.String())
@@ -198,7 +209,7 @@ func (m Model) renderRequestContext(region Region) string {
 	b.WriteString(accentOrMuted("Configuration", false))
 	b.WriteString(gapSection)
 	b.WriteString(fmt.Sprintf(indentField+"Method: %s\n", runconfig.AllowedMethods()[m.methodIndex]))
-	b.WriteString(fmt.Sprintf(indentField+"URL: %s\n", truncateURL(m.urlInput.Value(), region.Width-8)))
+	b.WriteString(fmt.Sprintf(indentField+"URL: %s\n", truncateURL(m.urlInput.Value(), region.Width-contextURLWidth)))
 	b.WriteString(fmt.Sprintf(indentField+"C: %d\n", m.concurrency()))
 	b.WriteString(fmt.Sprintf(indentField+"Payload: %s\n", m.payloadSummary()))
 	return regionStyle(region).Render(b.String())
@@ -245,7 +256,7 @@ func (m Model) renderTopBar(state ShellState, width int) string {
 		case "Method":
 			left = c.Value
 		case "URL":
-			left += " " + truncateURL(c.Value, 40)
+			left += " " + truncateURL(c.Value, topBarURLWidth)
 		case "Concurrency":
 			right = "C " + c.Value
 		case "Payload":
@@ -256,7 +267,7 @@ func (m Model) renderTopBar(state ShellState, width int) string {
 	}
 
 	maxLeft := width - lipgloss.Width(right) - 3
-	if maxLeft < 12 {
+	if maxLeft < topBarMinLeft {
 		maxLeft = 12
 	}
 	leftTruncated := truncate(left, maxLeft)
@@ -273,18 +284,48 @@ func (m Model) renderReady(region Region) string {
 	method := runconfig.AllowedMethods()[m.methodIndex]
 	url := m.urlInput.Value()
 	cc := m.concurrency()
-
 	payloadLabel := m.payloadSummary()
+
+	isDefaultMethod := m.methodIndex == 0
+	isDefaultURL := url == "" || url == defaultURL
+	isDefaultCC := cc == runconfig.DefaultConcurrency
 
 	var b strings.Builder
 	b.WriteString(styleMuted.Render("Ready"))
 	b.WriteString(gapSection)
 	b.WriteString(accentOrMuted("Current Request", true))
 	b.WriteString(gapSection)
-	b.WriteString("Method\n" + method + gapSection)
-	b.WriteString("URL\n" + url + gapSection)
-	b.WriteString(fmt.Sprintf("Concurrency\n%d"+gapSection, cc))
-	b.WriteString("Payload\n" + payloadLabel + gapSection)
+
+	b.WriteString("Method\n")
+	if isDefaultMethod {
+		b.WriteString(styleMuted.Render(method))
+	} else {
+		b.WriteString(method)
+	}
+	b.WriteString(gapSection)
+
+	b.WriteString("URL\n")
+	if url == "" {
+		b.WriteString(styleMuted.Render(sentinelEmpty))
+	} else if isDefaultURL {
+		b.WriteString(styleMuted.Render(url))
+	} else {
+		b.WriteString(url)
+	}
+	b.WriteString(gapSection)
+
+	b.WriteString("Concurrency\n")
+	if isDefaultCC {
+		b.WriteString(styleMuted.Render(fmt.Sprintf("%d", cc)))
+	} else {
+		b.WriteString(fmt.Sprintf("%d", cc))
+	}
+	b.WriteString(gapSection)
+
+	b.WriteString("Payload\n")
+	b.WriteString(payloadLabel)
+	b.WriteString(gapSection)
+
 	b.WriteString("Status\n")
 	b.WriteString(styleMuted.Render("Ready to execute"))
 
@@ -376,7 +417,7 @@ func (m Model) renderPayloadDomain(width int) string {
 	b.WriteString("\n")
 
 	headersActive := m.activeDomain == DomainPayload && m.selectedHead != bodyFocus
-	b.WriteString(accentOrMuted(indentField+"HEADERS  ctrl+n add  ctrl+d remove", headersActive))
+	b.WriteString(accentOrMuted(indentField+"HEADERS", headersActive))
 	b.WriteString("\n")
 
 	if len(m.headers) == 0 {
@@ -677,8 +718,12 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	status := resultStatus(result)
 	latency := formatDuration(result.Latency)
 	method := m.effectiveMethod(result)
+	reqURL := m.effectiveURL(result)
 
-	barWidth := max(6, width-34)
+	remaining := width - timelineFixedWidth
+	barWidth := max(6, remaining/2)
+	urlWidth := max(10, remaining-barWidth)
+
 	filled := 0
 	if maxLatency > 0 {
 		filled = int(float64(result.Latency) / float64(maxLatency) * float64(barWidth))
@@ -690,8 +735,8 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	barColor := statusColor(result.Status)
 	bar := renderLatencyBar(filled, barWidth, barColor)
 
-	line := fmt.Sprintf("%s %-4s %-12s %s %s",
-		rowCursor(selected), method, status, bar, latency)
+	line := fmt.Sprintf("%s %-4s %-12s %s %s %s",
+		rowCursor(selected), method, status, bar, latency, truncateURL(reqURL, urlWidth))
 
 	if isErrorResult(result) {
 		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
@@ -706,12 +751,70 @@ func (m Model) renderLogs(region Region) string {
 			method := m.effectiveMethod(result)
 			reqURL := m.effectiveURL(result)
 			line := fmt.Sprintf("%s %-4s %-10s %-8s %s",
-				rowCursor(selected), method, status, formatDuration(result.Latency), truncate(reqURL, width-29))
+				rowCursor(selected), method, status, formatDuration(result.Latency), truncate(reqURL, width-logsFixedWidth))
 			if isErrorResult(result) {
 				return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
 			}
 			return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
 		})
+}
+
+func (m Model) renderInspectSummary(result model.Result, method, reqURL string) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s %s", method, reqURL))
+	b.WriteString("\n")
+	b.WriteString(renderStatusBadge(result))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("Latency: %s", formatDuration(result.Latency)))
+	if result.Error != "" {
+		b.WriteString("\n")
+		b.WriteString(styleError.Render("Error: " + result.Error))
+	}
+	return b.String()
+}
+
+func (m Model) renderInspectHeadersText(result model.Result, maxLines int) string {
+	var b strings.Builder
+	if len(result.ResponseHeaders) == 0 {
+		b.WriteString(styleMuted.Render("No headers captured."))
+	} else {
+		keys := make([]string, 0, len(result.ResponseHeaders))
+		for key := range result.ResponseHeaders {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		lines := 0
+		for _, key := range keys {
+			if maxLines > 0 && lines >= maxLines {
+				b.WriteString(styleMuted.Render("..."))
+				break
+			}
+			b.WriteString(fmt.Sprintf("%s: %s", key, result.ResponseHeaders[key]))
+			b.WriteString("\n")
+			lines++
+		}
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func (m Model) renderInspectBodyText(result model.Result, maxLines int) string {
+	body := result.ResponseBody
+	if body == "" {
+		return styleMuted.Render("No body captured.")
+	}
+	bodyLines := strings.Split(body, "\n")
+	var b strings.Builder
+	for i, bline := range bodyLines {
+		if maxLines > 0 && i >= maxLines {
+			b.WriteString(styleMuted.Render("... (truncated)"))
+			break
+		}
+		b.WriteString(bline)
+		if i < len(bodyLines)-1 {
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
 }
 
 func (m Model) renderInspect(region Region) string {
@@ -722,55 +825,63 @@ func (m Model) renderInspect(region Region) string {
 	result := m.results[m.selected]
 	method := m.effectiveMethod(result)
 	reqURL := m.effectiveURL(result)
+	identity := identityCell(fmt.Sprintf("Result %d", m.selected+1))
+
+	summaryBlock := m.renderInspectSummary(result, method, reqURL)
 
 	sectionLine := func(label string) string {
 		return styleSectionLine.Render("── " + label + " ──")
 	}
 
-	identity := identityCell(fmt.Sprintf("Result %d", m.selected+1))
+	switch {
+	case region.Width >= 90:
+		summaryW := region.Width * 25 / 100
+		headersW := region.Width * 35 / 100
+		bodyW := region.Width - summaryW - headersW - 2
 
-	lines := []string{
-		identity,
-		gapSection,
-		fmt.Sprintf("%s %s", method, truncate(reqURL, region.Width-4)),
-		renderStatusBadge(result),
-		fmt.Sprintf("Latency: %s", formatDuration(result.Latency)),
-	}
-	if result.Error != "" {
-		lines = append(lines, styleError.Render("Error: "+result.Error))
-	}
-	lines = append(lines, gapSection, sectionLine("HEADERS"))
+		summaryRendered := lipgloss.NewStyle().Width(summaryW).Render(
+			identity + "\n\n" + summaryBlock)
+		headersRendered := lipgloss.NewStyle().Width(headersW).Render(
+			sectionLine("HEADERS") + "\n" + m.renderInspectHeadersText(result, region.Height-2))
+		bodyRendered := lipgloss.NewStyle().Width(bodyW).Render(
+			sectionLine("BODY") + "\n" + m.renderInspectBodyText(result, region.Height-2))
 
-	if len(result.ResponseHeaders) == 0 {
-		lines = append(lines, styleMuted.Render("No headers captured."))
-	} else {
-		keys := make([]string, 0, len(result.ResponseHeaders))
-		for key := range result.ResponseHeaders {
-			keys = append(keys, key)
+		combined := lipgloss.JoinHorizontal(lipgloss.Top, summaryRendered, " ", headersRendered, " ", bodyRendered)
+		return regionStyle(region).Render(combined)
+
+	case region.Width >= 60:
+		summaryH := 6
+		halfW := (region.Width - 1) / 2
+		remainingH := region.Height - summaryH - 2
+
+		top := lipgloss.NewStyle().Width(region.Width).Render(
+			identity + "\n\n" + summaryBlock)
+
+		headersRendered := lipgloss.NewStyle().Width(halfW).Render(
+			sectionLine("HEADERS") + "\n" + m.renderInspectHeadersText(result, remainingH-1))
+		bodyRendered := lipgloss.NewStyle().Width(region.Width - halfW - 1).Render(
+			sectionLine("BODY") + "\n" + m.renderInspectBodyText(result, remainingH-1))
+
+		bottom := lipgloss.JoinHorizontal(lipgloss.Top, headersRendered, " ", bodyRendered)
+		combined := top + "\n" + bottom
+		return regionStyle(region).Render(combined)
+
+	default:
+		lines := []string{
+			identity,
+			gapSection,
+			summaryBlock,
+			gapSection,
+			sectionLine("HEADERS"),
 		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			lines = append(lines, truncate(fmt.Sprintf("%s: %s", key, result.ResponseHeaders[key]), region.Width-4))
-		}
-	}
+		headersText := m.renderInspectHeadersText(result, region.Height-8)
+		lines = append(lines, headersText)
+		lines = append(lines, gapSection, sectionLine("BODY"))
+		bodyText := m.renderInspectBodyText(result, region.Height-10)
+		lines = append(lines, bodyText)
 
-	lines = append(lines, gapSection, sectionLine("BODY"))
-	body := result.ResponseBody
-	if body == "" {
-		body = styleMuted.Render("No body captured.")
+		return regionStyle(region).Render(strings.Join(lines, "\n"))
 	}
-	bodyLines := strings.Split(body, "\n")
-	for i, bline := range bodyLines {
-		if len(lines) >= region.Height-2 {
-			if i < len(bodyLines)-1 {
-				lines = append(lines, styleMuted.Render("... (truncated)"))
-			}
-			break
-		}
-		lines = append(lines, truncate(bline, region.Width-4))
-	}
-
-	return regionStyle(region).Render(strings.Join(lines, "\n"))
 }
 
 func resultStatus(result model.Result) string {


### PR DESCRIPTION
Four sequenced themes completed for v0.9.4.

Theme 1: Ready Workspace Defaults
Extract the defaultURL constant. The Ready surface now detects default method, URL, and concurrency values and renders them in muted style. Use sentinelEmpty when the URL is empty. The Ready surface persists between runs instead of disappearing after the first execution.

Theme 2: Inspect Workspace Region Composition
Three responsive layouts for the Inspect workspace: wide horizontal split at 90 or more columns, medium top summary with bottom split at 60 or more columns, and compact stacked layout below that. Extract renderInspectSummary, renderInspectHeadersText, and renderInspectBodyText as semantic subrenderers.

Theme 3: Workspace Language Consistency
Remove keyboard hints from the Payload domain header labels. Add a URL column to Timeline rows. Use semantic constants for width calculations throughout the renderer.

Theme 4: Engineering Convergence and Semantic Constants Remove the styleHeading declaration. Replace styleBase.Copy() with direct assignment at all three sites. Extract a semantic constants block including timelineFixedWidth, logsFixedWidth, contextRowWidth, contextURLWidth, minPanelWidth, and defaultBodySplitDiv. Fix the region border dash width to span the full width including side padding. Extract topBarURLWidth and topBarMinLeft constants. Replace magic values with named runconfig constants in the concurrency clamp test.

Verification:
  go fmt ./...: clean
  go vet ./...: clean
  go build ./...: clean
  go test -count=1 ./...: all 9 packages pass
  go test -race -count=1 ./...: clean
  staticcheck ./...: clean
  go mod tidy: clean

Closes #123, #124, #125, #126, #127