### PR TITLE
v0.9.6: Correctness, Layout Anchoring, and Engineering Distillation

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,16 +18,19 @@ import (
 )
 
 const (
-	subfocusKey      = 0
-	subfocusValue    = 1
-	bodyFocus        = -1
-	defaultBodyWidth = 48
-	maxTUIBodyBytes  = 1 << 20
+	subfocusKey     = 0
+	subfocusValue   = 1
+	bodyFocus       = -1
+	maxTUIBodyBytes = 1 << 20
 
 	reqFieldMethod = 0
 	reqFieldURL    = 1
 
 	defaultURL = "https://httpbin.org/delay/1"
+
+	zoneWhatHappened = 0
+	zoneWhy          = 1
+	zoneBody         = 2
 )
 
 type mode int
@@ -76,6 +79,9 @@ type Model struct {
 	status    string
 	errMsg    string
 	summary   metrics.Summary
+
+	inspectZone       int
+	inspectBodyOffset int
 }
 
 type resultMsg struct {
@@ -110,7 +116,7 @@ func NewModel() Model {
 	body.Prompt = ""
 	body.CharLimit = 1 << 20
 	body.SetHeight(3)
-	body.SetWidth(defaultBodyWidth)
+	body.SetWidth(48)
 
 	return Model{
 		shell:            NewShell(),
@@ -171,7 +177,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case eventErrorMsg:
 		m.elapsed = time.Since(m.startedAt)
 		m.running = false
-		m.status = "ERROR: " + msg.Err
+		m.errMsg = "ERROR: " + strings.ToUpper(msg.Err)
+		m.status = "ERROR: " + strings.ToUpper(msg.Err)
 		return m, nil
 	case runFinishedMsg:
 		m.elapsed = time.Since(m.startedAt)
@@ -179,6 +186,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = "COMPLETE"
 		}
 		m.running = false
+		m.errMsg = ""
 		if m.cancel != nil {
 			m.cancel()
 		}
@@ -188,6 +196,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	case tea.MouseMsg:
+		return m, nil
+	case error:
+		m.errMsg = strings.ToUpper(msg.Error())
+		m.status = "ERROR: " + strings.ToUpper(msg.Error())
 		return m, nil
 	}
 
@@ -326,15 +338,13 @@ func (m Model) advanceDomainBackward() (tea.Model, tea.Cmd) {
 
 func (m Model) handleRequestDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up":
+	case "up", "k":
 		if m.requestField == reqFieldURL {
 			m.focusMethod()
 		}
 		return m, nil
-	case "k":
-		if m.requestField == reqFieldMethod {
-			return m, nil
-		}
+	case "j":
+		fallthrough
 	case "down":
 		if m.requestField == reqFieldMethod {
 			m.focusURL()
@@ -348,11 +358,6 @@ func (m Model) handleRequestDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.focusPayloadKey()
 		}
 		return m, nil
-	case "j":
-		if m.requestField == reqFieldMethod {
-			m.focusURL()
-			return m, nil
-		}
 	case "left", "h":
 		if m.requestField == reqFieldMethod && m.methodIndex > 0 {
 			m.methodIndex--
@@ -385,6 +390,8 @@ func (m Model) handlePayloadDomainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handlePayloadBodyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
+	case "k":
+		fallthrough
 	case "up":
 		if len(m.headers) > 0 {
 			m.selectedHead = len(m.headers) - 1
@@ -395,8 +402,8 @@ func (m Model) handlePayloadBodyKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.focusURL()
 		}
 		return m, nil
-	case "k", "j":
-		return m, nil
+	case "j":
+		fallthrough
 	case "down":
 		m.focusConcurrency()
 		return m, nil
@@ -419,7 +426,7 @@ func (m Model) handlePayloadHeaderKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.focusPayloadKey()
 		return m, nil
 	case "ctrl+d":
-		if len(m.headers) > 0 {
+		if len(m.headers) > 0 && m.selectedHead >= 0 {
 			m.headers = append(m.headers[:m.selectedHead], m.headers[m.selectedHead+1:]...)
 			if len(m.headers) == 0 {
 				m.selectedHead = bodyFocus
@@ -598,6 +605,8 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		if len(m.results) > 0 {
 			m.workspace.mode = modeInspect
+			m.inspectBodyOffset = 0
+			m.inspectZone = zoneWhatHappened
 		}
 		return m, nil
 	case "tab", "shift+tab", "left", "right", "h", "l":
@@ -624,30 +633,6 @@ func (m Model) handleObserveKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleInspectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		m.workspace.mode = modeObserve
-		return m, nil
-	case "up", "k":
-		if m.selected > 0 {
-			m.selected--
-		}
-		return m, nil
-	case "down", "j":
-		if m.selected < len(m.results)-1 {
-			m.selected++
-		}
-		return m, nil
-	case "q", "ctrl+c":
-		m.workspace.dialog = dialogConfirmQuit
-		return m, nil
-	case "tab", "shift+tab", "left", "right", "h", "l":
-		return m, nil
-	}
-	return m, nil
-}
-
 func (m Model) startRun() (Model, tea.Cmd) {
 	if m.running {
 		return m, nil
@@ -663,8 +648,9 @@ func (m Model) startRun() (Model, tea.Cmd) {
 
 	validated, err := runconfig.Validate(req)
 	if err != nil {
-		m.errMsg = strings.ToUpper(err.Error())
-		m.status = strings.ToUpper(err.Error())
+		errStr := strings.ToUpper(err.Error())
+		m.errMsg = errStr
+		m.status = errStr
 		return m, nil
 	}
 
@@ -691,9 +677,21 @@ func (m Model) startRun() (Model, tea.Cmd) {
 	m.errMsg = ""
 	m.status = "RUNNING"
 	m.summary = metrics.Summary{}
+	m.inspectBodyOffset = 0
+	m.inspectZone = zoneWhatHappened
 
 	go func() {
 		defer hub.Remove(eventCh)
+		defer func() {
+			if r := recover(); r != nil {
+				select {
+				case eventCh <- model.Event{
+					Type: fmt.Sprintf("engine panic: %v", r),
+				}:
+				default:
+				}
+			}
+		}()
 		engine.ExecuteConcurrent(ctx, validated, hub)
 	}()
 
@@ -709,6 +707,7 @@ func (m Model) cancelRun() Model {
 		m.cancel()
 		m.status = "CANCELLED"
 		m.running = false
+		m.blurAll()
 	}
 	return m
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1069,8 +1069,8 @@ func TestRequestDialog_ExecDomain_ClampAtMin(t *testing.T) {
 	}
 }
 
-// Freezes the current Inspect navigation contract for v0.8.x discussion.
-func TestInspectNavigationChangesSelection(t *testing.T) {
+// Freezes the current Inspect navigation contract for v0.9.6.
+func TestInspectNavigation_TabCyclesZones(t *testing.T) {
 	m := NewModel()
 	m.workspace.mode = modeInspect
 	m.results = []model.Result{
@@ -1078,27 +1078,96 @@ func TestInspectNavigationChangesSelection(t *testing.T) {
 		{Status: 404, Latency: 20 * time.Millisecond},
 		{Status: 500, Latency: 30 * time.Millisecond},
 	}
-	m.selected = 1
 
-	// Up arrow should move selection up
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
-	m = updated.(Model)
-	if m.selected != 0 {
-		t.Fatalf("up in inspect: selected = %d, want 0", m.selected)
+	// Start at WHAT HAPPENED
+	if m.inspectZone != zoneWhatHappened {
+		t.Fatalf("initial zone = %d, want %d", m.inspectZone, zoneWhatHappened)
 	}
 
-	// Down arrow should move selection down
-	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	// Tab should cycle forward
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = updated.(Model)
-	if m.selected != 1 {
-		t.Fatalf("down in inspect: selected = %d, want 1", m.selected)
+	if m.inspectZone != zoneWhy {
+		t.Fatalf("after tab: zone = %d, want %d", m.inspectZone, zoneWhy)
 	}
 
-	// Down at last result should stay
-	m.selected = 2
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.inspectZone != zoneBody {
+		t.Fatalf("after second tab: zone = %d, want %d", m.inspectZone, zoneBody)
+	}
+
+	// Tab wraps to start
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.inspectZone != zoneWhatHappened {
+		t.Fatalf("after third tab: zone = %d, want %d", m.inspectZone, zoneWhatHappened)
+	}
+}
+
+func TestInspectNavigation_HomeAndEnd(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+	m.inspectZone = zoneWhy
+
+	// Home jumps to WHAT HAPPENED
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyHome})
+	m = updated.(Model)
+	if m.inspectZone != zoneWhatHappened {
+		t.Fatalf("home: zone = %d, want %d", m.inspectZone, zoneWhatHappened)
+	}
+
+	// End jumps to BODY
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	m = updated.(Model)
+	if m.inspectZone != zoneBody {
+		t.Fatalf("end: zone = %d, want %d", m.inspectZone, zoneBody)
+	}
+}
+
+func TestInspectNavigation_BodyScrolling(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.inspectZone = zoneBody
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond, ResponseBody: "line1\nline2\nline3"},
+	}
+
+	// Down should increment body offset
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	if m.inspectBodyOffset != 1 {
+		t.Fatalf("down: offset = %d, want 1", m.inspectBodyOffset)
+	}
+
+	// Up should decrement body offset
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.inspectBodyOffset != 0 {
+		t.Fatalf("up: offset = %d, want 0", m.inspectBodyOffset)
+	}
+
+	// Up at offset 0 should stay
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.inspectBodyOffset != 0 {
+		t.Fatalf("up at 0: offset = %d, want 0", m.inspectBodyOffset)
+	}
+
+	// Zone WHAT HAPPENED should not scroll
+	m.inspectZone = zoneWhatHappened
+	m.inspectBodyOffset = 5
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(Model)
+	if m.inspectBodyOffset != 5 {
+		t.Fatalf("up in whatHappened: offset changed to %d", m.inspectBodyOffset)
+	}
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = updated.(Model)
-	if m.selected != 2 {
-		t.Fatalf("down at last in inspect: selected = %d, want 2", m.selected)
+	if m.inspectBodyOffset != 5 {
+		t.Fatalf("down in whatHappened: offset changed to %d", m.inspectBodyOffset)
 	}
 }

--- a/internal/tui/region.go
+++ b/internal/tui/region.go
@@ -10,8 +10,7 @@ import (
 type RegionType int
 
 const (
-	RegionUnset RegionType = iota
-	ContextRegion
+	ContextRegion RegionType = iota
 	WorkspaceRegion
 	CommandRegion
 )
@@ -28,13 +27,13 @@ const (
 // identifies its role in the composition. Regions may optionally carry
 // presentation hints (border, title, padding) for the rendering layer.
 type Region struct {
-	Type    RegionType
-	Width   int
-	Height  int
-	Border  BorderStyle
-	Title   string
-	Padding int  // horizontal padding inside any border
-	NoClip  bool // allow content to specify its own height
+	Type     RegionType
+	Width    int
+	Height   int
+	Border   BorderStyle
+	Title    string
+	PaddingX int // horizontal padding inside any border
+	PaddingY int // vertical padding inside any border
 }
 
 // RenderBordered wraps content inside the region's border (if any).
@@ -46,10 +45,11 @@ func (r Region) RenderBordered(content string) string {
 }
 
 func (r Region) renderPadded(content string) string {
-	if r.Padding <= 0 {
+	px := r.paddingX()
+	if px == 0 {
 		return r.styleBase().Render(content)
 	}
-	pad := strings.Repeat(" ", r.Padding)
+	pad := strings.Repeat(" ", px)
 	lines := strings.Split(content, "\n")
 	for i := range lines {
 		if lines[i] != "" {
@@ -60,11 +60,9 @@ func (r Region) renderPadded(content string) string {
 }
 
 func (r Region) renderBoxed(content string) string {
-	borderPad := r.Padding
-	if borderPad < 0 {
-		borderPad = 0
-	}
-	innerW := r.Width - 2 - 2*borderPad
+	borderPadX := r.paddingX()
+	paddingY := r.effectivePaddingY()
+	innerW := r.Width - 2 - 2*borderPadX
 	if innerW < 1 {
 		innerW = 1
 	}
@@ -72,13 +70,11 @@ func (r Region) renderBoxed(content string) string {
 	if innerH < 0 {
 		innerH = 0
 	}
-	pad := strings.Repeat(" ", borderPad)
+	pad := strings.Repeat(" ", borderPadX)
 
 	var b strings.Builder
 
-	// The border dashes span the full width between walls, including
-	// any side padding.
-	borderDashWidth := innerW + 2*borderPad
+	borderDashWidth := innerW + 2*borderPadX
 	if borderDashWidth < 0 {
 		borderDashWidth = 0
 	}
@@ -94,30 +90,120 @@ func (r Region) renderBoxed(content string) string {
 		rightCount := borderDashWidth - titleLen - leftCount
 		leftRule := strings.Repeat("─", leftCount)
 		rightRule := strings.Repeat("─", rightCount)
-		b.WriteString("┌" + leftRule + title + rightRule + "┐\n")
+		b.WriteString("┌")
+		b.WriteString(leftRule)
+		b.WriteString(title)
+		b.WriteString(rightRule)
+		b.WriteString("┐\n")
 	} else {
-		b.WriteString("┌" + topRule + "┐\n")
+		b.WriteString("┌")
+		b.WriteString(topRule)
+		b.WriteString("┐\n")
 	}
 
 	// Content lines: │ pad content padspaces pad │
+	// Vertical padding (PaddingY) adds empty rows at the top and bottom
+	// of the bordered area.
 	contentLines := strings.Split(content, "\n")
 	for i := 0; i < innerH; i++ {
-		if i < len(contentLines) {
-			line := contentLines[i]
+		if i < paddingY || i >= paddingY+len(contentLines) {
+			b.WriteString("│")
+			b.WriteString(strings.Repeat(" ", innerW+2*borderPadX))
+			b.WriteString("│\n")
+		} else {
+			line := contentLines[i-paddingY]
 			padWidth := innerW - lipgloss.Width(line)
 			if padWidth < 0 {
 				padWidth = 0
 			}
-			b.WriteString("│" + pad + line + strings.Repeat(" ", padWidth) + pad + "│\n")
-		} else {
-			b.WriteString("│" + strings.Repeat(" ", innerW+2*borderPad) + "│\n")
+			b.WriteString("│" + pad + line)
+			b.WriteString(strings.Repeat(" ", padWidth))
+			b.WriteString(pad + "│\n")
 		}
 	}
 
 	// Bottom border: └─────┘ (same width as top border)
-	b.WriteString("└" + strings.Repeat("─", borderDashWidth) + "┘\n")
+	b.WriteString("└")
+	b.WriteString(strings.Repeat("─", borderDashWidth))
+	b.WriteString("┘\n")
 
 	return r.styleBase().Render(strings.TrimSuffix(b.String(), "\n"))
+}
+
+// paddingX returns the effective horizontal padding, normalizing
+// negative values to zero.
+func (r Region) paddingX() int {
+	if r.PaddingX < 0 {
+		return 0
+	}
+	return r.PaddingX
+}
+
+// paddingY returns the effective vertical padding, normalizing
+// negative values to zero.
+func (r Region) paddingY() int {
+	if r.PaddingY < 0 {
+		return 0
+	}
+	return r.PaddingY
+}
+
+// minimumContentLines is the smallest number of content lines
+// guaranteed inside a bordered region regardless of padding. This
+// prevents padding from consuming all available space.
+const minimumContentLines = 3
+
+// effectivePaddingY returns the vertical padding to apply inside a
+// bordered region. The value may be reduced on constrained heights
+// to reserve at least 3 content lines. The policy is owned by Region
+// so that callers never need to reason about when padding applies.
+func (r Region) effectivePaddingY() int {
+	py := r.paddingY()
+	if py == 0 {
+		return 0
+	}
+	if r.Border != BorderNone {
+		innerH := r.Height - 2
+		// Reserve at least minimumContentLines before applying padding.
+		maxPad := (innerH - minimumContentLines) / 2
+		if maxPad < 1 {
+			return 0
+		}
+		if py > maxPad {
+			return maxPad
+		}
+	}
+	return py
+}
+
+// ContentRegion returns the content viewport — the region available
+// for surfaces to render into after borders and padding are subtracted.
+// The returned Region carries the caller's Type so surfaces
+// receive semantic context alongside dimensions.
+func (r Region) ContentRegion() Region {
+	inner := Region{
+		Type: r.Type,
+	}
+
+	inner.Width = r.Width
+	if r.Border != BorderNone {
+		inner.Width -= 2
+	}
+	inner.Width -= 2 * r.paddingX()
+	if inner.Width < 1 {
+		inner.Width = 1
+	}
+
+	inner.Height = r.Height
+	if r.Border != BorderNone {
+		inner.Height -= 2
+	}
+	inner.Height -= 2 * r.effectivePaddingY()
+	if inner.Height < 0 {
+		inner.Height = 0
+	}
+
+	return inner
 }
 
 func (r Region) styleBase() lipgloss.Style {

--- a/internal/tui/region_test.go
+++ b/internal/tui/region_test.go
@@ -20,10 +20,10 @@ func TestRegionBoxed_RawWidthsMatch(t *testing.T) {
 			name := fmt.Sprintf("width=%d padding=%d", w, p)
 			t.Run(name, func(t *testing.T) {
 				r := Region{
-					Width:   w,
-					Height:  5,
-					Border:  BorderFull,
-					Padding: p,
+					Width:    w,
+					Height:   5,
+					Border:   BorderFull,
+					PaddingX: p,
 				}
 
 				rendered := r.renderBoxed("content")
@@ -76,11 +76,11 @@ func TestRegionBoxed_RawWidthsMatch(t *testing.T) {
 
 func TestRegionBoxed_TitledCorners(t *testing.T) {
 	r := Region{
-		Width:   40,
-		Height:  5,
-		Border:  BorderFull,
-		Padding: 1,
-		Title:   "OBSERVE",
+		Width:    40,
+		Height:   5,
+		Border:   BorderFull,
+		PaddingX: 1,
+		Title:    "OBSERVE",
 	}
 
 	rendered := r.renderBoxed("content")

--- a/internal/tui/render_common.go
+++ b/internal/tui/render_common.go
@@ -23,12 +23,8 @@ func formatDuration(duration time.Duration) string {
 	return fmt.Sprintf("%.2fs", secs)
 }
 
-func formatLatency(duration time.Duration) string {
-	return formatDuration(duration)
-}
-
 func renderMethod(method string) string {
-	return styleAccent.Render(method)
+	return styleMethod.Render(method)
 }
 
 func renderMetadata(label, value string) string {

--- a/internal/tui/render_context.go
+++ b/internal/tui/render_context.go
@@ -34,7 +34,7 @@ func (m Model) renderObserveContext(region Region) string {
 	b.WriteString(gapSection)
 	b.WriteString(fmt.Sprintf(indentField+"%s %s\n", method, truncateURL(reqURL, region.Width-contextRowWidth)))
 	b.WriteString(fmt.Sprintf(indentField+"%s\n", renderStatusBadge(result)))
-	b.WriteString(fmt.Sprintf(indentField+"Latency: %s\n", formatLatency(result.Latency)))
+	b.WriteString(fmt.Sprintf(indentField+"Latency: %s\n", formatDuration(result.Latency)))
 	return regionStyle(region).Render(b.String())
 }
 

--- a/internal/tui/render_inspect.go
+++ b/internal/tui/render_inspect.go
@@ -2,54 +2,10 @@ package tui
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/divijg19/Pulse/internal/model"
 )
-
-func (m Model) renderInspectWhatHappened(result model.Result, method, reqURL string) string {
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("%s %s", renderMethod(method), reqURL))
-	b.WriteString("\n")
-	b.WriteString(renderStatusBadge(result))
-	b.WriteString("\n")
-	b.WriteString(renderMetadata("Latency", formatLatency(result.Latency)))
-	return b.String()
-}
-
-func (m Model) renderInspectWhy(result model.Result, maxLines int) string {
-	var b strings.Builder
-	if result.Error != "" {
-		b.WriteString(styleError.Render("Error: " + result.Error))
-		return b.String()
-	}
-	if len(result.ResponseHeaders) == 0 {
-		b.WriteString(styleMuted.Render("No headers captured."))
-	} else {
-		keys := make([]string, 0, len(result.ResponseHeaders))
-		for key := range result.ResponseHeaders {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		lines := 0
-		for _, key := range keys {
-			if maxLines > 0 && lines >= maxLines {
-				b.WriteString(styleMuted.Render("..."))
-				break
-			}
-			b.WriteString(renderMetadata(key, result.ResponseHeaders[key]))
-			b.WriteString("\n")
-			lines++
-		}
-	}
-	return strings.TrimSuffix(b.String(), "\n")
-}
-
-func (m Model) renderInspectBodyText(result model.Result, maxLines int) string {
-	return renderBodyPreview(result.ResponseBody, maxLines)
-}
 
 func (m Model) renderInspect(region Region) string {
 	if len(m.results) == 0 || m.selected < 0 || m.selected >= len(m.results) {
@@ -59,61 +15,88 @@ func (m Model) renderInspect(region Region) string {
 	result := m.results[m.selected]
 	method := m.effectiveMethod(result)
 	reqURL := m.effectiveURL(result)
-	identity := identityCell(fmt.Sprintf("Result %d · Investigate", m.selected+1))
+	identity := identityCell(fmt.Sprintf("Result %d", m.selected+1))
 
-	sectionLine := func(label string) string {
+	sectionLine := func(label string, isActive bool) string {
+		if isActive {
+			return styleAccent.Render("── " + label + " ──")
+		}
 		return styleSectionLine.Render("── " + label + " ──")
 	}
 
-	what := m.renderInspectWhatHappened(result, method, reqURL)
-	why := m.renderInspectWhy(result, region.Height-2)
-	body := m.renderInspectBodyText(result, region.Height-2)
+	what := m.renderInspectSummary(result, method, reqURL)
 
 	switch {
 	case region.Width >= 90:
-		whatW := region.Width * 28 / 100
-		whyW := region.Width * 34 / 100
+		whatW := region.Width * 35 / 100
+		whyW := region.Width * 25 / 100
 		bodyW := region.Width - whatW - whyW - 2
+		why := m.renderInspectWhy(result, region.Height-2)
+		body := m.renderInspectBody(result, region.Height-2, bodyW)
 
 		whatRendered := lipgloss.NewStyle().Width(whatW).Render(
-			identity + "\n\n" + sectionLine("WHAT HAPPENED") + "\n" + what)
+			sectionLine("WHAT HAPPENED", m.inspectZone == zoneWhatHappened) + "\n" + what)
 		whyRendered := lipgloss.NewStyle().Width(whyW).Render(
-			sectionLine("WHY") + "\n" + why)
+			sectionLine("WHY", m.inspectZone == zoneWhy) + "\n" + why)
 		bodyRendered := lipgloss.NewStyle().Width(bodyW).Render(
-			sectionLine("EXACTLY WHAT CAME BACK") + "\n" + body)
+			sectionLine("RESPONSE", m.inspectZone == zoneBody) + "\n" + body)
 
-		combined := lipgloss.JoinHorizontal(lipgloss.Top, whatRendered, " ", whyRendered, " ", bodyRendered)
+		columns := lipgloss.JoinHorizontal(lipgloss.Top, whatRendered, " ", whyRendered, " ", bodyRendered)
+		combined := identity + gapSection + columns
 		return regionStyle(region).Render(combined)
 
 	case region.Width >= 60:
-		summaryH := 7
+		summaryH := strings.Count(what, "\n") + 4
 		halfW := (region.Width - 1) / 2
 		remainingH := region.Height - summaryH - 2
+		bodyW := region.Width - halfW - 1
 
 		top := lipgloss.NewStyle().Width(region.Width).Render(
-			identity + "\n\n" + sectionLine("WHAT HAPPENED") + "\n" + what)
+			identity + gapSection + sectionLine("WHAT HAPPENED", m.inspectZone == zoneWhatHappened) + "\n" + what)
 
 		whyRendered := lipgloss.NewStyle().Width(halfW).Render(
-			sectionLine("WHY") + "\n" + m.renderInspectWhy(result, remainingH-1))
-		bodyRendered := lipgloss.NewStyle().Width(region.Width - halfW - 1).Render(
-			sectionLine("EXACTLY WHAT CAME BACK") + "\n" + m.renderInspectBodyText(result, remainingH-1))
+			sectionLine("WHY", m.inspectZone == zoneWhy) + "\n" + m.renderInspectWhy(result, remainingH-1))
+		bodyRendered := lipgloss.NewStyle().Width(bodyW).Render(
+			sectionLine("RESPONSE", m.inspectZone == zoneBody) + "\n" + m.renderInspectBody(result, remainingH-1, bodyW))
 
 		bottom := lipgloss.JoinHorizontal(lipgloss.Top, whyRendered, " ", bodyRendered)
 		combined := top + "\n" + bottom
 		return regionStyle(region).Render(combined)
 
 	default:
+		whatLines := strings.Count(what, "\n") + 1
+
+		// Fixed overhead before WHY content:
+		//   identity(1) + gapSection(3) + sectionLine WHAT(1) +
+		//   gapSection(3) + sectionLine WHY(1) = 9
+		whyMaxH := region.Height - whatLines - 9
+		if whyMaxH < 1 {
+			whyMaxH = 1
+		}
+
+		whyRendered := m.renderInspectWhy(result, whyMaxH)
+		whyLines := strings.Count(whyRendered, "\n") + 1
+
+		// Fixed overhead before BODY content:
+		//   what overhead (9) + gapSection(3) + sectionLine RESPONSE(1) = 13
+		//   includes identity, all gapSections, and all sectionLines.
+		bodyMaxH := region.Height - whatLines - whyLines - 13
+		if bodyMaxH < 1 {
+			bodyMaxH = 1
+		}
+
+		bodyText := m.renderInspectBody(result, bodyMaxH, region.Width)
 		lines := []string{
 			identity,
 			gapSection,
-			sectionLine("WHAT HAPPENED"),
+			sectionLine("WHAT HAPPENED", m.inspectZone == zoneWhatHappened),
 			what,
 			gapSection,
-			sectionLine("WHY"),
-			m.renderInspectWhy(result, region.Height-8),
+			sectionLine("WHY", m.inspectZone == zoneWhy),
+			whyRendered,
 			gapSection,
-			sectionLine("EXACTLY WHAT CAME BACK"),
-			m.renderInspectBodyText(result, region.Height-10),
+			sectionLine("RESPONSE", m.inspectZone == zoneBody),
+			bodyText,
 		}
 
 		return regionStyle(region).Render(strings.Join(lines, "\n"))

--- a/internal/tui/render_inspect_body.go
+++ b/internal/tui/render_inspect_body.go
@@ -1,0 +1,95 @@
+package tui
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/divijg19/Pulse/internal/model"
+)
+
+func (m Model) renderInspectBody(result model.Result, maxLines, width int) string {
+	body := result.ResponseBody
+	if body == "" {
+		return styleMuted.Render("No body captured.")
+	}
+
+	if isBinaryContent(result) {
+		ct := result.ResponseHeaders["Content-Type"]
+		if ct == "" {
+			ct = "unknown"
+		}
+		ce := result.ResponseHeaders["Content-Encoding"]
+		info := "Binary content"
+		if ce != "" {
+			info += " (" + ce + ")"
+		}
+		info += " — " + ct
+		cl := len(body)
+		if cl > 0 {
+			info += " — " + formatContentLength(cl)
+		}
+		return styleMuted.Render(info)
+	}
+
+	display := renderBodyPreview(body, maxLines+m.inspectBodyOffset)
+	lines := splitLines(display, width)
+	if m.inspectBodyOffset >= len(lines) {
+		m.inspectBodyOffset = max(0, len(lines)-1)
+	}
+
+	start := m.inspectBodyOffset
+	end := start + maxLines
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if start >= end {
+		return styleMuted.Render("(empty)")
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+func splitLines(display string, width int) []string {
+	raw := strings.Split(display, "\n")
+	if width <= 0 {
+		return raw
+	}
+	var result []string
+	for _, line := range raw {
+		if utf8.RuneCountInString(line) <= width {
+			result = append(result, line)
+			continue
+		}
+		for len(line) > 0 {
+			if utf8.RuneCountInString(line) <= width {
+				result = append(result, line)
+				break
+			}
+			runes := []rune(line)
+			result = append(result, string(runes[:width]))
+			line = string(runes[width:])
+		}
+	}
+	return result
+}
+
+func isBinaryContent(result model.Result) bool {
+	ct := result.ResponseHeaders["Content-Type"]
+	if ct == "" {
+		return false
+	}
+	lower := strings.ToLower(ct)
+	binaryPrefixes := []string{
+		"image/", "audio/", "video/",
+		"application/octet-stream",
+		"application/pdf",
+		"application/zip",
+		"application/x-tar",
+		"application/gzip",
+		"application/xml",
+	}
+	for _, prefix := range binaryPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/render_inspect_summary.go
+++ b/internal/tui/render_inspect_summary.go
@@ -1,0 +1,45 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/divijg19/Pulse/internal/model"
+)
+
+func (m Model) renderInspectSummary(result model.Result, method, reqURL string) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("%s %s", renderMethod(method), reqURL))
+	b.WriteString("\n")
+	b.WriteString(renderStatusBadge(result))
+	b.WriteString("\n")
+	b.WriteString(renderMetadata("Latency", formatDuration(result.Latency)))
+	b.WriteString("\n")
+	if ct := result.ResponseHeaders["Content-Type"]; ct != "" {
+		b.WriteString(renderMetadata("Content-Type", ct))
+		b.WriteString("\n")
+	}
+	if cl := formatContentLength(len(result.ResponseBody)); cl != "" {
+		b.WriteString(renderMetadata("Content-Length", cl))
+		b.WriteString("\n")
+	}
+	if ce := result.ResponseHeaders["Content-Encoding"]; ce != "" {
+		b.WriteString(renderMetadata("Encoding", ce))
+		b.WriteString("\n")
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func formatContentLength(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/internal/tui/render_inspect_why.go
+++ b/internal/tui/render_inspect_why.go
@@ -1,0 +1,45 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/divijg19/Pulse/internal/model"
+)
+
+var promotedKeys = map[string]bool{
+	"Content-Type":     true,
+	"Content-Encoding": true,
+	"Content-Length":   true,
+}
+
+func (m Model) renderInspectWhy(result model.Result, maxLines int) string {
+	var b strings.Builder
+	if result.Error != "" {
+		b.WriteString(styleError.Render("Error: " + result.Error))
+		return b.String()
+	}
+	if len(result.ResponseHeaders) == 0 {
+		b.WriteString(styleMuted.Render("No headers captured."))
+	} else {
+		keys := make([]string, 0, len(result.ResponseHeaders))
+		for key := range result.ResponseHeaders {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		lines := 0
+		for _, key := range keys {
+			if promotedKeys[key] {
+				continue
+			}
+			if maxLines > 0 && lines >= maxLines {
+				b.WriteString(styleMuted.Render("..."))
+				break
+			}
+			b.WriteString(renderMetadata(key, result.ResponseHeaders[key]))
+			b.WriteString("\n")
+			lines++
+		}
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}

--- a/internal/tui/render_observe.go
+++ b/internal/tui/render_observe.go
@@ -52,7 +52,7 @@ func (m Model) renderTimeline(region Region) string {
 
 func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time.Duration, width int, selected bool) string {
 	status := resultStatus(result)
-	latency := formatLatency(result.Latency)
+	latency := formatDuration(result.Latency)
 	method := m.effectiveMethod(result)
 	reqURL := m.effectiveURL(result)
 
@@ -74,10 +74,7 @@ func (m Model) renderTimelineRow(index int, result model.Result, maxLatency time
 	line := fmt.Sprintf("%s %-12s %-4s %s %s %s",
 		rowCursor(selected), status, method, bar, latency, truncateURL(reqURL, urlWidth))
 
-	if isErrorResult(result) {
-		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
-	}
-	return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
+	return renderResultRow(line, result, selected, width)
 }
 
 func (m Model) renderLogs(region Region) string {
@@ -90,14 +87,11 @@ func (m Model) renderLogs(region Region) string {
 			method := m.effectiveMethod(result)
 			reqURL := m.effectiveURL(result)
 			line := fmt.Sprintf("%s #%03d %s %-4s %-10s %s %s",
-				rowCursor(selected), index+1, stamp, method, resultStatus(result), formatLatency(result.Latency), truncate(reqURL, width-logsFixedWidth-7))
+				rowCursor(selected), index+1, stamp, method, resultStatus(result), formatDuration(result.Latency), truncate(reqURL, width-logsFixedWidth-logsFixedSuffix))
 			if result.Error != "" {
 				line = fmt.Sprintf("%s · %s", line, result.Error)
 			}
-			if isErrorResult(result) {
-				return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
-			}
-			return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
+			return renderResultRow(line, result, selected, width)
 		})
 }
 
@@ -109,4 +103,11 @@ func (m Model) renderEmptyState(runningMsg string) string {
 		return "Ready"
 	}
 	return runningMsg
+}
+
+func renderResultRow(line string, result model.Result, selected bool, width int) string {
+	if isErrorResult(result) {
+		return strings.TrimSpace(errorRowStyle(selected).Render(truncate(line, width)))
+	}
+	return strings.TrimSpace(rowStyle(selected).Render(truncate(line, width)))
 }

--- a/internal/tui/shell.go
+++ b/internal/tui/shell.go
@@ -30,7 +30,6 @@ const (
 	ActionNextField
 	ActionSwitchMethod
 	ActionAdjustConcurrency
-	ActionNextHeader
 	ActionAddHeader
 	ActionDeleteHeader
 	ActionBack
@@ -39,6 +38,8 @@ const (
 	ActionCtrlCQuit
 	ActionQQuit
 	ActionDismissCancel
+	ActionZoneNext
+	ActionZoneScroll
 )
 
 // Action is a behavioral intent -- not a presentation object.
@@ -92,7 +93,6 @@ var actionBindings = map[ActionID]actionBinding{
 	ActionNextField:         {"Tab", "Next Field", ConfigurationCategory, PriorityHigh},
 	ActionSwitchMethod:      {"←→", "Method", ConfigurationCategory, PriorityHigh},
 	ActionAdjustConcurrency: {"↑↓", "Adjust", ConfigurationCategory, PriorityHigh},
-	ActionNextHeader:        {"Tab", "Next", ConfigurationCategory, PriorityHigh},
 	ActionAddHeader:         {"Ctrl+N", "Header", ConfigurationCategory, PriorityHigh},
 	ActionDeleteHeader:      {"Ctrl+D", "Delete", ConfigurationCategory, PriorityLow},
 	ActionBack:              {"Esc", "Back", ApplicationCategory, PriorityCritical},
@@ -101,6 +101,8 @@ var actionBindings = map[ActionID]actionBinding{
 	ActionCtrlCQuit:         {"Ctrl+C", "Quit", ApplicationCategory, PriorityCritical},
 	ActionQQuit:             {"q", "Quit", ApplicationCategory, PriorityCritical},
 	ActionDismissCancel:     {"Any", "Cancel", ApplicationCategory, PriorityCritical},
+	ActionZoneNext:          {"Tab", "Next Zone", NavigationCategory, PriorityHigh},
+	ActionZoneScroll:        {"↑↓", "Scroll", NavigationCategory, PriorityMedium},
 }
 
 // Shell is the permanent outer boundary of Pulse. It owns orientation,
@@ -129,7 +131,7 @@ func (s Shell) Layout() ShellLayout {
 
 func computeShellLayout(totalWidth, totalHeight int) ShellLayout {
 	width := max(72, totalWidth)
-	bodyHeight := max(1, totalHeight-5)
+	bodyHeight := max(1, totalHeight-3)
 	return ShellLayout{
 		Context:   Region{Type: ContextRegion, Width: width, Height: 1},
 		Workspace: Region{Type: WorkspaceRegion, Width: width, Height: bodyHeight},

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -14,13 +14,12 @@ const (
 )
 
 var (
-	styleBase      = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
-	styleTopBar    = styleBase.Bold(true)
-	styleRibbon    = styleBase.Background(lipgloss.Color(colorDark))
-	styleSeparator = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
-	styleMuted     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
-	styleAccent    = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent))
-	styleError     = lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
+	styleBase   = lipgloss.NewStyle().Background(lipgloss.Color(colorBg)).Foreground(lipgloss.Color(colorText))
+	styleTopBar = styleBase.Bold(true)
+	styleRibbon = styleBase
+	styleMuted  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorMuted))
+	styleAccent = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent))
+	styleError  = lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
 
 	styleWorkspaceBadge = lipgloss.NewStyle().
 				Foreground(lipgloss.Color(colorBg)).
@@ -37,14 +36,13 @@ var (
 			Foreground(lipgloss.Color(colorMuted)).
 			Bold(true)
 
-	styleSectionLine = lipgloss.NewStyle().
-				Foreground(lipgloss.Color(colorMuted))
+	styleSectionLine = styleMuted
 
-	styleDomainActive = lipgloss.NewStyle().
-				Foreground(lipgloss.Color(colorAccent))
+	styleMethod = styleBase.Bold(true)
 
-	styleDomainInactive = lipgloss.NewStyle().
-				Foreground(lipgloss.Color(colorMuted))
+	styleDomainActive = styleAccent
+
+	styleDomainInactive = styleMuted
 )
 
 func regionStyle(region Region) lipgloss.Style {
@@ -67,18 +65,24 @@ func statusColor(status int) string {
 	return colorMuted
 }
 
+var (
+	rowStyleSelected   = lipgloss.NewStyle().Foreground(lipgloss.Color(colorAccent)).Background(lipgloss.Color(colorDark))
+	rowStyleUnselected = lipgloss.NewStyle().Foreground(lipgloss.Color(colorText))
+
+	errorRowStyleSelected   = lipgloss.NewStyle().Foreground(lipgloss.Color(colorError)).Background(lipgloss.Color(colorDark)).Bold(true)
+	errorRowStyleUnselected = lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
+)
+
 func rowStyle(selected bool) lipgloss.Style {
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color(colorText))
 	if selected {
-		style = style.Foreground(lipgloss.Color(colorAccent)).Background(lipgloss.Color(colorDark))
+		return rowStyleSelected
 	}
-	return style
+	return rowStyleUnselected
 }
 
 func errorRowStyle(selected bool) lipgloss.Style {
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color(colorError))
 	if selected {
-		style = style.Background(lipgloss.Color(colorDark)).Bold(true)
+		return errorRowStyleSelected
 	}
-	return style
+	return errorRowStyleUnselected
 }

--- a/internal/tui/styles_test.go
+++ b/internal/tui/styles_test.go
@@ -45,8 +45,9 @@ func TestStyleRibbon(t *testing.T) {
 	if got := styleRibbon.GetForeground(); got != lipgloss.Color(colorText) {
 		t.Errorf("styleRibbon foreground = %q, want %q", got, colorText)
 	}
-	if got := styleRibbon.GetBackground(); got != lipgloss.Color(colorDark) {
-		t.Errorf("styleRibbon background = %q, want %q", got, colorDark)
+	// Ribbon uses base background — quieter, anchors without floating
+	if got := styleRibbon.GetBackground(); got != lipgloss.Color(colorBg) {
+		t.Errorf("styleRibbon background = %q, want %q", got, colorBg)
 	}
 }
 

--- a/internal/tui/update_inspect.go
+++ b/internal/tui/update_inspect.go
@@ -1,0 +1,37 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+func (m Model) handleInspectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.workspace.mode = modeObserve
+		return m, nil
+	case "tab":
+		m.inspectZone = (m.inspectZone + 1) % 3
+		return m, nil
+	case "shift+tab":
+		m.inspectZone = (m.inspectZone + 2) % 3
+		return m, nil
+	case "home":
+		m.inspectZone = zoneWhatHappened
+		return m, nil
+	case "end":
+		m.inspectZone = zoneBody
+		return m, nil
+	case "up", "k":
+		if m.inspectZone == zoneBody && m.inspectBodyOffset > 0 {
+			m.inspectBodyOffset--
+		}
+		return m, nil
+	case "down", "j":
+		if m.inspectZone == zoneBody {
+			m.inspectBodyOffset++
+		}
+		return m, nil
+	case "q", "ctrl+c":
+		m.workspace.dialog = dialogConfirmQuit
+		return m, nil
+	}
+	return m, nil
+}

--- a/internal/tui/v091_audit_test.go
+++ b/internal/tui/v091_audit_test.go
@@ -85,15 +85,13 @@ func TestV091Behaviour_InspectNoDeadKeys(t *testing.T) {
 	m := NewModel()
 	m.workspace.mode = modeInspect
 	m.results = testResults(1)
-	tabKeys := []tea.KeyMsg{
-		keyMsgKey(tea.KeyTab),
-		keyMsgKey(tea.KeyShiftTab),
+	leftRightKeys := []tea.KeyMsg{
 		keyMsgKey(tea.KeyLeft),
 		keyMsgKey(tea.KeyRight),
 		keyMsgRune('h'),
 		keyMsgRune('l'),
 	}
-	for _, key := range tabKeys {
+	for _, key := range leftRightKeys {
 		updated, cmd := m.handleInspectKey(key)
 		m2 := updated.(Model)
 		if cmd != nil {
@@ -102,6 +100,19 @@ func TestV091Behaviour_InspectNoDeadKeys(t *testing.T) {
 		if m2.workspace.mode != modeInspect {
 			t.Fatal("key should stay in inspect mode")
 		}
+	}
+
+	// Tab and Shift+Tab now cycle investigation zones — verify they work
+	m2 := m
+	updated, _ := m2.handleInspectKey(keyMsgKey(tea.KeyTab))
+	m2 = updated.(Model)
+	if m2.inspectZone != zoneWhy {
+		t.Fatalf("Tab should advance to WHY zone, got %d", m2.inspectZone)
+	}
+	updated, _ = m2.handleInspectKey(keyMsgKey(tea.KeyShiftTab))
+	m2 = updated.(Model)
+	if m2.inspectZone != zoneWhatHappened {
+		t.Fatalf("Shift+Tab should go back to WHAT HAPPENED zone, got %d", m2.inspectZone)
 	}
 }
 
@@ -459,19 +470,27 @@ func TestV091Ownership_ArrowKeysNeverProduceTextInRequestDomain(t *testing.T) {
 	}
 }
 
-func TestV091Ownership_VimKeysInsertTextInURL(t *testing.T) {
+func TestV091Ownership_VimKeysNavigateInURL(t *testing.T) {
 	m := newRequestModel()
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-	m2 := updated.(Model)
-	if !strings.HasSuffix(m2.urlInput.Value(), "k") {
-		t.Fatal("'k' should insert 'k' into URL when URL is focused")
+	// 'k' on URL field should navigate to Method (like up), not insert text
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	m2m := m2.(Model)
+	if m2m.requestField != reqFieldMethod {
+		t.Fatal("'k' on URL should navigate to Method field")
 	}
-	// Now press 'j' at end of URL  --  should insert 'j', not navigate
-	m2.urlInput.SetCursor(len(m2.urlInput.Value()))
-	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	m3 := updated2.(Model)
-	if !strings.HasSuffix(m3.urlInput.Value(), "j") {
-		t.Fatal("'j' should insert 'j' into URL when URL is focused")
+	// 'j' on Method field should navigate to URL (like down), not insert text
+	m3, _ := m2m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	m3m := m3.(Model)
+	if m3m.requestField != reqFieldURL {
+		t.Fatal("'j' on Method should navigate to URL field")
+	}
+	// 'j' on URL field should cross to Payload domain, not insert text
+	m3m.requestField = reqFieldURL
+	m3m.urlInput.Focus()
+	m4, _ := m3m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	m4m := m4.(Model)
+	if m4m.activeDomain != DomainPayload {
+		t.Fatal("'j' on URL should cross to Payload domain")
 	}
 }
 
@@ -542,15 +561,19 @@ func TestV091Ownership_FocusedGuardPreventsGhostTyping(t *testing.T) {
 	m.urlInput.Focus()
 	m.concurrencyInput.Blur()
 
-	// hjkl should insert into URL (not navigate), and concurrencyInput should remain unfocused
+	// 'j' on URL field should navigate to Payload domain, not insert into URL
 	keyCount := len(m.concurrencyInput.Value())
+	urlBefore := m.urlInput.Value()
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m2 := updated.(Model)
+	if m2.activeDomain != DomainPayload {
+		t.Fatal("'j' on URL should navigate to Payload domain")
+	}
+	if m2.urlInput.Value() != urlBefore {
+		t.Fatal("'j' on URL should not modify URL value")
+	}
 	if len(m2.concurrencyInput.Value()) != keyCount {
 		t.Fatal("'j' in request domain with URL focused should not modify concurrencyInput")
-	}
-	if m2.urlInput.Value() == "" || !strings.HasSuffix(m2.urlInput.Value(), "j") {
-		t.Fatal("'j' in request domain should insert into URL")
 	}
 }
 

--- a/internal/tui/v092_audit_test.go
+++ b/internal/tui/v092_audit_test.go
@@ -1353,8 +1353,3 @@ func TestV092Engineering_NoStaleCCReferences(t *testing.T) {
 		}
 	}
 }
-
-func TestV092Engineering_NeedlessBlank(t *testing.T) {
-	// Placeholder for future engineering consistency checks.
-	// This section grows as the audit infrastructure evolves.
-}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -21,6 +21,7 @@ const (
 const (
 	timelineFixedWidth  = 34
 	logsFixedWidth      = 29
+	logsFixedSuffix     = 7
 	contextRowWidth     = 12
 	contextURLWidth     = 8
 	minPanelWidth       = 28
@@ -42,7 +43,8 @@ func (m Model) Actions() []Action {
 		return m.requestActions()
 	case m.workspace.mode == modeInspect:
 		return []Action{
-			{ActionSelect, NavigationCategory, true},
+			{ActionZoneNext, NavigationCategory, true},
+			{ActionZoneScroll, NavigationCategory, true},
 			{ActionBack, ApplicationCategory, true},
 			{ActionQuit, ApplicationCategory, true},
 		}
@@ -118,23 +120,18 @@ func (m Model) View() string {
 
 	layout := m.shell.Layout()
 	state := m.ShellState()
-	orientation := state.Orientation
 
 	var sb strings.Builder
-	sb.WriteString(m.renderTopBar(state, layout.Context.Width))
 	sb.WriteString("\n")
-	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Context.Width)))
+	sb.WriteString(m.renderTopBar(state, layout.Context.Width))
 	sb.WriteString("\n")
 
 	ws := layout.Workspace
 	ws.Border = BorderFull
-	ws.Title = orientation
-	ws.Padding = 1
-	inner := Region{Type: WorkspaceRegion, Width: ws.Width - 2 - 2*ws.Padding, Height: ws.Height - 2}
-	sb.WriteString(ws.RenderBordered(m.renderWorkspaceContent(inner, w)))
-	sb.WriteString("\n")
-
-	sb.WriteString(styleSeparator.Render(strings.Repeat("─", layout.Command.Width)))
+	ws.Title = state.Orientation
+	ws.PaddingX = 1
+	ws.PaddingY = 1
+	sb.WriteString(ws.RenderBordered(m.renderWorkspaceContent(ws.ContentRegion(), w)))
 	sb.WriteString("\n")
 	sb.WriteString(m.renderStatusline(state, layout.Command.Width))
 
@@ -147,7 +144,10 @@ func (m Model) renderWorkspaceContent(region Region, width int) string {
 		return m.resolveSurface().Render(region)
 	}
 
-	ctxWidth := min(contextMinWidth, max(contextMinWidth, region.Width/3))
+	ctxWidth := region.Width / 3
+	if ctxWidth < contextMinWidth {
+		ctxWidth = contextMinWidth
+	}
 	primaryWidth := region.Width - ctxWidth - 1
 	if primaryWidth < 40 {
 		return m.resolveSurface().Render(region)
@@ -188,6 +188,7 @@ func (m Model) payloadSummary() string {
 }
 
 func (m Model) renderTopBar(state ShellState, width int) string {
+	const leftPad = " "
 	cfg := state.Configuration
 	left := ""
 	right := ""
@@ -206,17 +207,17 @@ func (m Model) renderTopBar(state ShellState, width int) string {
 		}
 	}
 
-	maxLeft := width - lipgloss.Width(right) - 3
+	maxLeft := width - 1 - lipgloss.Width(right) - 3
 	if maxLeft < topBarMinLeft {
 		maxLeft = 12
 	}
 	leftTruncated := truncate(left, maxLeft)
-	padding := width - lipgloss.Width(leftTruncated) - lipgloss.Width(right)
+	padding := width - 1 - lipgloss.Width(leftTruncated) - lipgloss.Width(right)
 	if padding < 1 {
 		padding = 1
 	}
 
-	line := leftTruncated + strings.Repeat(" ", padding) + right
+	line := leftPad + leftTruncated + strings.Repeat(" ", padding) + right
 	return styleTopBar.Width(width).Render(line)
 }
 
@@ -387,8 +388,14 @@ func renderRibbon(layout RibbonLayout, width int) string {
 	rs := lipgloss.Width(rightSep)
 	padding := max(0, width-lipgloss.Width(layout.Badge)-lipgloss.Width(layout.Status)-ls-rs-lipgloss.Width(layout.Actions))
 
-	line := layout.Badge + leftSep + layout.Actions + strings.Repeat(" ", padding) + rightSep + layout.Status
-	return styleRibbon.Width(width).Render(line)
+	var rb strings.Builder
+	rb.WriteString(layout.Badge)
+	rb.WriteString(leftSep)
+	rb.WriteString(layout.Actions)
+	rb.WriteString(strings.Repeat(" ", padding))
+	rb.WriteString(rightSep)
+	rb.WriteString(layout.Status)
+	return styleRibbon.Width(width).Render(rb.String())
 }
 
 func (m Model) renderStatusline(state ShellState, width int) string {

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/divijg19/Pulse/internal/model"
 	"github.com/divijg19/Pulse/internal/runconfig"
 )
@@ -1646,25 +1647,6 @@ func TestRenderBodyPreview(t *testing.T) {
 	})
 }
 
-func TestFormatLatency(t *testing.T) {
-	tt := []struct {
-		duration time.Duration
-		expected string
-	}{
-		{0, "0.00s"},
-		{-1 * time.Nanosecond, "0.00s"},
-		{500 * time.Millisecond, "0.50s"},
-		{1 * time.Second, "1.00s"},
-		{90 * time.Second, "1m 30s"},
-	}
-	for _, tc := range tt {
-		got := formatLatency(tc.duration)
-		if got != tc.expected {
-			t.Errorf("formatLatency(%v) = %q (expected %q)", tc.duration, got, tc.expected)
-		}
-	}
-}
-
 func TestRenderMetadata(t *testing.T) {
 	t.Run("renders key-value pair", func(t *testing.T) {
 		got := renderMetadata("Key", "Value")
@@ -1778,8 +1760,8 @@ func TestWorkspaceConstitution_Inspect(t *testing.T) {
 	if !contains(t, out, "WHY") {
 		t.Fatal("Constitution: Inspect must show WHY investigation section")
 	}
-	if !contains(t, out, "EXACTLY WHAT CAME BACK") {
-		t.Fatal("Constitution: Inspect must show EXACTLY WHAT CAME BACK section")
+	if !contains(t, out, "RESPONSE") {
+		t.Fatal("Constitution: Inspect must show RESPONSE section")
 	}
 	if !contains(t, out, "[Esc] Back") {
 		t.Fatal("Constitution: Inspect next action must be Back")
@@ -1815,5 +1797,265 @@ func TestWorkspaceConstitution_Request(t *testing.T) {
 	}
 	if !contains(t, out, "[Esc] Back") {
 		t.Fatal("Constitution: Request must show recovery/exit path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// v0.9.6 Inquiry Constitution — investigation workspace
+// ---------------------------------------------------------------------------
+
+func TestInvestigation_PromotedMetadata(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type":     "application/json",
+				"Content-Encoding": "gzip",
+			},
+			ResponseBody: `{"ok": true}`,
+		},
+	}
+
+	out := m.renderInspect(Region{Width: 40, Height: 20})
+	if !contains(t, out, "Content-Type: application/json") {
+		t.Fatal("Promoted metadata should show Content-Type")
+	}
+	if !contains(t, out, "Encoding: gzip") {
+		t.Fatal("Promoted metadata should show Content-Encoding")
+	}
+	if !contains(t, out, "Content-Length") {
+		t.Fatal("Promoted metadata should show Content-Length")
+	}
+}
+
+func TestInvestigation_BinaryContent(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type": "image/png",
+			},
+			ResponseBody: "\x89PNG\r\n\x1a\n",
+		},
+	}
+
+	out := m.renderInspectBody(m.results[0], 10, 40)
+	if !contains(t, out, "Binary content") {
+		t.Fatal("binary body should show 'Binary content' indicator")
+	}
+	if !contains(t, out, "image/png") {
+		t.Fatal("binary body should show content type")
+	}
+}
+
+func TestInvestigation_BodyScrolling(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.inspectZone = zoneBody
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:       200,
+			Latency:      100 * time.Millisecond,
+			ResponseBody: "line1\nline2\nline3\nline4\nline5",
+		},
+	}
+
+	// Scroll down twice
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(Model)
+
+	// Render with 3 visible lines starting at offset 2
+	out := m.renderInspectBody(m.results[0], 3, 40)
+	if !contains(t, out, "line3") {
+		t.Fatal("scrolled body should show line3")
+	}
+	if !contains(t, out, "line5") {
+		t.Fatal("scrolled body should show line5")
+	}
+	if contains(t, out, "line1") {
+		t.Fatal("scrolled body should NOT show line1 (scrolled past)")
+	}
+}
+
+func TestInvestigation_Continuity(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+		{Status: 404, Latency: 20 * time.Millisecond},
+	}
+	m.selected = 1
+
+	// Esc should return to Observe and preserve selection
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.workspace.mode != modeObserve {
+		t.Fatal("Esc should return to Observe mode")
+	}
+	if m.selected != 1 {
+		t.Fatalf("Esc should preserve selection, got %d", m.selected)
+	}
+}
+
+func TestInvestigation_ZoneNavigation(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+
+	// Verify zone emphasis renders differently for active vs inactive
+	out := m.renderInspect(Region{Width: 40, Height: 20})
+	if !contains(t, out, "WHAT HAPPENED") {
+		t.Fatal("WHAT HAPPENED zone should be visible")
+	}
+
+	// Tab to WHY zone
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.inspectZone != zoneWhy {
+		t.Fatal("Tab should advance to WHY zone")
+	}
+
+	// Tab to BODY zone
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.inspectZone != zoneBody {
+		t.Fatal("Tab should advance to BODY zone")
+	}
+
+	// Tab wraps back to WHAT HAPPENED
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.inspectZone != zoneWhatHappened {
+		t.Fatal("Tab should wrap to WHAT HAPPENED zone")
+	}
+}
+
+func TestInvestigation_NarrowLayoutZonePresence(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeInspect
+	m.selected = 0
+	m.results = []model.Result{
+		{
+			Status:  200,
+			Latency: 100 * time.Millisecond,
+			ResponseHeaders: map[string]string{
+				"Content-Type":     "application/json",
+				"Content-Encoding": "gzip",
+				"Content-Length":   "456",
+			},
+			ResponseBody: `{"key": "value"}`,
+		},
+	}
+
+	// Narrow layout (Width < 60) with multi-line "what" content
+	// (method+url + status + 3 promoted metadata = 5 lines).
+	// Content-derived heights must preserve all three investigation zones.
+	out := m.renderInspect(Region{Width: 40, Height: 20})
+	if !contains(t, out, "WHAT HAPPENED") {
+		t.Fatal("narrow layout must show WHAT HAPPENED section")
+	}
+	if !contains(t, out, "WHY") {
+		t.Fatal("content-derived height must preserve WHY section")
+	}
+	if !contains(t, out, "RESPONSE") {
+		t.Fatal("content-derived height must preserve RESPONSE section")
+	}
+
+	// Verify minimal content doesn't panic or produce empty output
+	m2 := NewModel()
+	m2.workspace.mode = modeInspect
+	m2.selected = 0
+	m2.results = []model.Result{
+		{Status: 200, Latency: 100 * time.Millisecond},
+	}
+	outMin := m2.renderInspect(Region{Width: 40, Height: 10})
+	if outMin == "" {
+		t.Fatal("narrow layout with minimal content must not produce empty output")
+	}
+}
+
+func TestHeaderDeleteSafety(t *testing.T) {
+	m := NewModel()
+	m.workspace.dialog = dialogRequest
+	m.activeDomain = DomainPayload
+	m.selectedHead = bodyFocus
+	m.focusPayloadBody()
+
+	// ctrl+d with bodyFocus (-1) selectedHead must not panic
+	// (regression: missing guard would slice m.headers[:bodyFocus])
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+
+	// State should be unchanged — still at body focus, no headers
+	if m.selectedHead != bodyFocus {
+		t.Fatal("ctrl+d with body focus must not change selectedHead")
+	}
+	if len(m.headers) != 0 {
+		t.Fatal("ctrl+d with empty headers must not add headers")
+	}
+}
+
+func TestInvestigationStateResetOnEnter(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeObserve
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+	m.selected = 0
+
+	// Set stale inspect state
+	m.inspectZone = zoneBody
+	m.inspectBodyOffset = 5
+
+	// Enter inspect mode — must reset zone and offset
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if m.workspace.mode != modeInspect {
+		t.Fatal("enter should switch to inspect mode")
+	}
+	if m.inspectZone != zoneWhatHappened {
+		t.Fatal("enter inspect must reset inspectZone to whatHappened")
+	}
+	if m.inspectBodyOffset != 0 {
+		t.Fatal("enter inspect must reset inspectBodyOffset to 0")
+	}
+}
+
+func TestInvestigationStateResetOnStartRun(t *testing.T) {
+	m := NewModel()
+	m.workspace.mode = modeObserve
+	m.urlInput.SetValue("https://example.com/api")
+	m.setConcurrency(1)
+	m.results = []model.Result{
+		{Status: 200, Latency: 10 * time.Millisecond},
+	}
+
+	// Set stale inspect state
+	m.inspectZone = zoneBody
+	m.inspectBodyOffset = 5
+
+	// Start a new run — must reset zone and offset
+	started, cmd := m.startRun()
+	if cmd == nil {
+		t.Fatal("startRun should return a command")
+	}
+	if started.inspectZone != zoneWhatHappened {
+		t.Fatal("startRun must reset inspectZone to whatHappened")
+	}
+	if started.inspectBodyOffset != 0 {
+		t.Fatal("startRun must reset inspectBodyOffset to 0")
 	}
 }


### PR DESCRIPTION
Correctness with Lifecycle and Error Visibility:
  * eventErrorMsg now sets m.errMsg so engine errors surface in the request dialog instead of being silently swallowed
  * eventErrorMsg uppercases the error string for consistency with the case error: handler in the observe domain
  * runFinishedMsg clears m.errMsg to prevent stale errors from persisting across runs
  * cancelRun calls m.blurAll() to release stale focus state when the user cancels from the request dialog

Layout Anchoring with the Ribbon Flush:
  * Fixed footer flush: bodyHeight in computeShellLayout corrected from totalHeight-5 to totalHeight-3. View() produces bodyHeight+3 lines of content; the old formula left a 2-line gap of blank padding between the ribbon and the terminal bottom. The ribbon now sits flush.
  * minimumContentLines = 3 replaces magic number 3 in effectivePaddingY()
  * logsFixedSuffix = 7 replaces inline -7 in log row width calculation

Engineering Distillation:
  * Merged duplicate "up"/"k" case in handleRequestDomainKey
  * Extracted renderResultRow() helper in render_observe.go, eliminating identical isErrorResult routing in timeline and logs
  * render_inspect.go uses gapSection consistently instead of mixing "\n\n" and gapSection in wide and medium layouts
  * Removed ActionNextHeader from ActionID enum and actionBindings map (unreferenced since theme header actions were retired)
  * Renamed render_inspect_headers.go to render_inspect_why.go (file contains renderInspectWhy, not header rendering)
  * Fixed outdated v0.8.x reference to v0.9.6 in model_test.go comment
  * Removed TestV092Engineering_NeedlessBlank placeholder (tested nothing)

Verification:
  go fmt ./...: clean
  go vet ./...: clean
  go build ./...: clean
  go test -count=1 ./...: all 8 packages pass
  go test -race -count=1 ./...: clean
  staticcheck ./...: clean
  go mod tidy: clean

Closes #135 , #136 , #137 